### PR TITLE
Optimization - replace typedefs in `Ast.hx` with `@:structInit` classes

### DIFF
--- a/src/Ast.hx
+++ b/src/Ast.hx
@@ -2,7 +2,7 @@ package;
 
 /*typedef Node = {
 	pos:Int
-};*/
+}*/
 typedef Expr = Dynamic;
 typedef Stmt = Dynamic;
 typedef ExprType = Dynamic;
@@ -20,446 +20,514 @@ enum abstract ObjKind(Int) {
 	public final lbl = 7; // label
 }
 
-typedef Comment = {
-	text:String,
-	pos:Int,
-};
+@:structInit
+class Comment {
+	public var text:String;
+	public var pos:Int;
 
-typedef CommentGroup = {
-	list:Array<Comment>,
-};
-
-typedef Field = {
-	doc:CommentGroup,
-	names:Array<Ident>,
-	type:Expr,
-	tag:String,
-	comment:CommentGroup,
-};
-
-typedef FieldList = {
-	opening:Pos,
-	list:Array<Field>,
-	closing:Pos,
-};
-
-typedef BadExpr = {
-	// > Node,
-	from:Pos,
-	to:Pos,
-};
-
-typedef Ident = {
-	name:String,
-	type:ExprType,
-	?kind:ObjKind,
+	public function new(text:String, pos:Int) {
+		this.text = text;
+		this.pos = pos;
+	}
 }
 
-typedef Ellipsis = {
-	// > Node,
-	ellipsis:Pos,
-	elt:Expr,
-};
+@:structInit
+class CommentGroup {
+	public var list:Array<Comment>;
 
-typedef BasicLit = {
-	// > Node,
-	valuePos:Pos,
-	kind:Token,
-	type:ExprType,
-	value:String,
-	raw:Bool,
-};
-
-typedef FuncLit = {
-	// > Node,
-	type:FuncType,
-	body:BlockStmt,
-};
-
-typedef CompositeLit = {
-	// > Node,
-	type:Expr,
-	lbrace:Pos,
-	elts:Array<Expr>,
-	rbrace:Pos,
-	incomplete:Bool,
-};
-
-typedef ParenExpr = {
-	// > Node,
-	lparen:Pos,
-	x:Expr,
-	rparen:Pos,
-};
-
-typedef SelectorExpr = {
-	// > Node,
-	x:Expr,
-	sel:Ident,
-	recv:ExprType,
-	type:ExprType,
-};
-
-typedef IndexExpr = {
-	// > Node,
-	x:Expr,
-	lbrack:Pos,
-	index:Expr,
-	rbrack:Pos,
-	type:ExprType,
-};
-
-typedef IndexListExpr = {
-	x:Expr,
-	indices:Array<Expr>,
-	lbrack:Pos,
-	rbrack:Pos,
-	type:ExprType,
+	public function new(list:Array<Comment>) {
+		this.list = list;
+	}
 }
 
-typedef SliceExpr = {
-	// > Node,
-	x:Expr,
-	lbrack:Pos,
-	low:Expr,
-	high:Expr,
-	max:Expr,
-	slice3:Bool,
-	rbrack:Pos,
-	type:ExprType,
-};
+@:structInit
+class Field {
+	public var doc:CommentGroup;
+	public var names:Array<Ident>;
+	public var type:Expr;
+	public var tag:String;
+	public var comment:CommentGroup;
+}
 
-typedef TypeAssertExpr = {
-	// > Node,
-	x:Expr,
-	lparen:Pos,
-	type:Expr,
-	rparen:Pos,
-};
+@:structInit
+class FieldList {
+	public var opening:Pos;
+	public var list:Array<Field>;
+	public var closing:Pos;
+}
 
-typedef CallExpr = {
+@:structInit
+class BadExpr {
 	// > Node,
-	fun:Expr,
-	lparen:Pos,
-	args:Array<Expr>,
-	ellipsis:Pos,
-	rparen:Pos,
-	type:ExprType,
-};
+	public var from:Pos;
+	public var to:Pos;
+}
 
-typedef StarExpr = {
+@:structInit
+class Ident {
+	public var name:String;
+	public var type:ExprType;
+	?public var kind:ObjKind;
+}
+
+@:structInit
+class Ellipsis {
 	// > Node,
-	star:Pos,
-	x:Expr,
-	type:ExprType,
-};
+	public var ellipsis:Pos;
+	public var elt:Expr;
+}
 
-typedef UnaryExpr = {
+@:structInit
+class BasicLit {
 	// > Node,
-	opPos:Pos,
-	op:Token,
-	x:Expr,
-};
+	public var valuePos:Pos;
+	public var kind:Token;
+	public var type:ExprType;
+	public var value:String;
+	public var raw:Bool;
+}
 
-typedef BinaryExpr = {
+@:structInit
+class FuncLit {
 	// > Node,
-	x:Expr,
-	opPos:Pos,
-	op:Token,
-	y:Expr,
-	type:ExprType,
-};
+	public var type:FuncType;
+	public var body:BlockStmt;
+}
 
-typedef KeyValueExpr = {
+@:structInit
+class CompositeLit {
 	// > Node,
-	key:Expr,
-	colon:Pos,
-	value:Expr,
-};
+	public var type:Expr;
+	public var lbrace:Pos;
+	public var elts:Array<Expr>;
+	public var rbrace:Pos;
+	public var incomplete:Bool;
+}
 
-typedef ArrayType = {
+@:structInit
+class ParenExpr {
 	// > Node,
-	lbrack:Pos,
-	len:Expr,
-	elt:Expr,
-	type:ExprType,
-};
+	public var lparen:Pos;
+	public var x:Expr;
+	public var rparen:Pos;
+}
 
-typedef StructType = {
+@:structInit
+class SelectorExpr {
 	// > Node,
-	struct:Pos,
-	fields:FieldList,
-	incomplete:Bool,
-	type:ExprType,
-};
+	public var x:Expr;
+	public var sel:Ident;
+	public var recv:ExprType;
+	public var type:ExprType;
+}
 
-typedef PointerType = {
-	elem:ExprType,
-};
-
-typedef FuncType = {
+@:structInit
+class IndexExpr {
 	// > Node,
-	func:Pos,
-	params:FieldList,
-	results:FieldList,
-	typeParams:FieldList,
-	type:ExprType,
-};
+	public var x:Expr;
+	public var lbrack:Pos;
+	public var index:Expr;
+	public var rbrack:Pos;
+	public var type:ExprType;
+}
 
-typedef InterfaceType = {
+@:structInit
+class IndexListExpr {
+	public var x:Expr;
+	public var indices:Array<Expr>;
+	public var lbrack:Pos;
+	public var rbrack:Pos;
+	public var type:ExprType;
+}
+
+@:structInit
+class SliceExpr {
 	// > Node,
-	interfacePos:Pos,
+	public var x:Expr;
+	public var lbrack:Pos;
+	public var low:Expr;
+	public var high:Expr;
+	public var max:Expr;
+	public var slice3:Bool;
+	public var rbrack:Pos;
+	public var type:ExprType;
+}
+
+@:structInit
+class TypeAssertExpr {
+	// > Node,
+	public var x:Expr;
+	public var lparen:Pos;
+	public var type:Expr;
+	public var rparen:Pos;
+}
+
+@:structInit
+class CallExpr {
+	// > Node,
+	public var fun:Expr;
+	public var lparen:Pos;
+	public var args:Array<Expr>;
+	public var ellipsis:Pos;
+	public var rparen:Pos;
+	public var type:ExprType;
+}
+
+@:structInit
+class StarExpr {
+	// > Node,
+	public var star:Pos;
+	public var x:Expr;
+	public var type:ExprType;
+}
+
+@:structInit
+class UnaryExpr {
+	// > Node,
+	public var opPos:Pos;
+	public var op:Token;
+	public var x:Expr;
+}
+
+@:structInit
+class BinaryExpr {
+	// > Node,
+	public var x:Expr;
+	public var opPos:Pos;
+	public var op:Token;
+	public var y:Expr;
+	public var type:ExprType;
+}
+
+@:structInit
+class KeyValueExpr {
+	// > Node,
+	public var key:Expr;
+	public var colon:Pos;
+	public var value:Expr;
+}
+
+@:structInit
+class ArrayType {
+	// > Node,
+	public var lbrack:Pos;
+	public var len:Expr;
+	public var elt:Expr;
+	public var type:ExprType;
+}
+
+@:structInit
+class StructType {
+	// > Node,
+	public var struct:Pos;
+	public var fields:FieldList;
+	public var incomplete:Bool;
+	public var type:ExprType;
+}
+
+@:structInit
+class PointerType {
+	public var elem:ExprType;
+}
+
+@:structInit
+class FuncType {
+	// > Node,
+	public var func:Pos;
+	public var params:FieldList;
+	public var results:FieldList;
+	public var typeParams:FieldList;
+	public var type:ExprType;
+}
+
+@:structInit
+class InterfaceType {
+	// > Node,
+	public var interfacePos:Pos;
 	// interface TODO: turn interface -> inter
-	methods:FieldList,
-	incomplete:Bool,
-	type:ExprType,
-};
+	public var methods:FieldList;
+	public var incomplete:Bool;
+	public var type:ExprType;
+}
 
-typedef MapType = {
+@:structInit
+class MapType {
 	// > Node,
-	map:Pos,
-	key:Expr,
-	value:Expr,
-	type:ExprType,
-};
+	public var map:Pos;
+	public var key:Expr;
+	public var value:Expr;
+	public var type:ExprType;
+}
 
-typedef ChanType = {
+@:structInit
+class ChanType {
 	// > Node,
-	begin:Pos,
-	arrow:Pos,
-	dir:ChanDir,
-	value:Expr,
-	type:ExprType,
-};
+	public var begin:Pos;
+	public var arrow:Pos;
+	public var dir:ChanDir;
+	public var value:Expr;
+	public var type:ExprType;
+}
 
-typedef BadStmt = {
+@:structInit
+class BadStmt {
 	// > Node,
-	from:Pos,
-	to:Pos,
-};
+	public var from:Pos;
+	public var to:Pos;
+}
 
-typedef DeclStmt = {
+@:structInit
+class DeclStmt {
 	// > Node,
-	decl:Decl,
-};
+	public var decl:Decl;
+}
 
-typedef EmptyStmt = {
+@:structInit
+class EmptyStmt {
 	// > Node,
-	semicolon:Pos,
-	implicit:Bool,
-};
+	public var semicolon:Pos;
+	public var implicit:Bool;
+}
 
-typedef LabeledStmt = {
+@:structInit
+class LabeledStmt {
 	// > Node,
-	label:Ident,
-	colon:Pos,
-	stmt:Stmt,
-};
+	public var label:Ident;
+	public var colon:Pos;
+	public var stmt:Stmt;
+}
 
-typedef ExprStmt = {
+@:structInit
+class ExprStmt {
 	// > Node,
-	x:Expr,
-	end:Int,
-	pos:Int,
-};
+	public var x:Expr;
+	public var end:Int;
+	public var pos:Int;
+}
 
-typedef SendStmt = {
+@:structInit
+class SendStmt {
 	// > Node,
-	chan:Expr,
-	arrow:Pos,
-	value:Expr,
-};
+	public var chan:Expr;
+	public var arrow:Pos;
+	public var value:Expr;
+}
 
-typedef IncDecStmt = {
+@:structInit
+class IncDecStmt {
 	// > Node,
-	x:Expr,
-	tokPos:Pos,
-	tok:Token,
-};
+	public var x:Expr;
+	public var tokPos:Pos;
+	public var tok:Token;
+}
 
-typedef AssignStmt = {
+@:structInit
+class AssignStmt {
 	// > Node,
-	lhs:Array<Expr>,
-	tokPos:Pos,
-	tok:Token,
-	rhs:Array<Expr>,
-};
+	public var lhs:Array<Expr>;
+	public var tokPos:Pos;
+	public var tok:Token;
+	public var rhs:Array<Expr>;
+}
 
-typedef GoStmt = {
+@:structInit
+class GoStmt {
 	// > Node,
-	go:Pos,
-	call:CallExpr,
-};
+	public var go:Pos;
+	public var call:CallExpr;
+}
 
-typedef DeferStmt = {
+@:structInit
+class DeferStmt {
 	// > Node,
-	defer:Pos,
-	call:CallExpr,
-};
+	public var defer:Pos;
+	public var call:CallExpr;
+}
 
-typedef ReturnStmt = {
+@:structInit
+class ReturnStmt {
 	// > Node,
-	returnPos:Pos,
+	public var returnPos:Pos;
 	// return TODO: return -> returnPos
-	results:Array<Expr>,
-};
+	public var results:Array<Expr>;
+}
 
-typedef BranchStmt = {
-	tokPos:Pos,
-	tok:Token,
-	label:Ident,
-};
+@:structInit
+class BranchStmt {
+	public var tokPos:Pos;
+	public var tok:Token;
+	public var label:Ident;
+}
 
-typedef BlockStmt = {
-	lbrace:Pos,
-	list:Array<Stmt>,
-	rbrace:Pos,
-};
+@:structInit
+class BlockStmt {
+	public var lbrace:Pos;
+	public var list:Array<Stmt>;
+	public var rbrace:Pos;
+}
 
-typedef IfStmt = {
-	ifPos:Pos,
+@:structInit
+class IfStmt {
+	public var ifPos:Pos;
 	// if TODO: if -> ifPos
-	init:Stmt,
-	cond:Expr,
-	body:BlockStmt,
-	elseStmt:Stmt,
+	public var init:Stmt;
+	public var cond:Expr;
+	public var body:BlockStmt;
+	public var elseStmt:Stmt;
 	// else TODO: else -> elseStmt
-};
+}
 
-typedef CaseClause = {
-	casePos:Pos,
+@:structInit
+class CaseClause {
+	public var casePos:Pos;
 	// case TODO: case -> casePos
-	list:Array<Expr>,
-	colon:Pos,
-	body:Array<Stmt>,
-};
+	public var list:Array<Expr>;
+	public var colon:Pos;
+	public var body:Array<Stmt>;
+}
 
-typedef SwitchStmt = {
-	switchPos:Pos,
+@:structInit
+class SwitchStmt {
+	public var switchPos:Pos;
 	// switch TODO: switch -> switchPos
-	init:Stmt,
-	tag:Expr,
-	body:BlockStmt,
-};
+	public var init:Stmt;
+	public var tag:Expr;
+	public var body:BlockStmt;
+}
 
-typedef TypeSwitchStmt = {
-	switchPos:Pos,
+@:structInit
+class TypeSwitchStmt {
+	public var switchPos:Pos;
 	// switch TODO: switch -> switchPos
-	init:Stmt,
-	assign:Stmt,
-	body:BlockStmt,
-};
+	public var init:Stmt;
+	public var assign:Stmt;
+	public var body:BlockStmt;
+}
 
-typedef CommClause = {
-	casePos:Pos,
+@:structInit
+class CommClause {
+	public var casePos:Pos;
 	// case TODO: case -> casePos
-	comm:Stmt,
-	colon:Pos,
-	body:Array<Stmt>,
-};
+	public var comm:Stmt;
+	public var colon:Pos;
+	public var body:Array<Stmt>;
+}
 
-typedef SelectStmt = {
-	select:Pos,
-	body:BlockStmt,
-};
+@:structInit
+class SelectStmt {
+	public var select:Pos;
+	public var body:BlockStmt;
+}
 
-typedef ForStmt = {
-	forPos:Pos,
+@:structInit
+class ForStmt {
+	public var forPos:Pos;
 	// for TODO: for -> forPos
-	init:Stmt,
-	cond:Expr,
-	post:Stmt,
-	body:BlockStmt,
-};
+	public var init:Stmt;
+	public var cond:Expr;
+	public var post:Stmt;
+	public var body:BlockStmt;
+}
 
-typedef RangeStmt = {
-	forPos:Pos,
+@:structInit
+class RangeStmt {
+	public var forPos:Pos;
 	// for TODO: for -> forPos
-	key:Expr,
-	value:Expr,
-	tokPos:Pos,
-	tok:Token,
-	x:Expr,
-	body:BlockStmt,
-};
+	public var key:Expr;
+	public var value:Expr;
+	public var tokPos:Pos;
+	public var tok:Token;
+	public var x:Expr;
+	public var body:BlockStmt;
+}
 
 typedef Spec = Dynamic; // A go interface
 
-typedef ImportSpec = {
-	doc:CommentGroup,
-	name:String,
+@:structInit
+class ImportSpec {
+	public var doc:CommentGroup;
+	public var name:String;
 	// Ident
-	path:String,
-	comment:CommentGroup,
-	endPos:Pos,
-};
+	public var path:String;
+	public var comment:CommentGroup;
+	public var endPos:Pos;
+}
 
-typedef ValueSpec = {
-	doc:CommentGroup,
+@:structInit
+class ValueSpec {
+	public var doc:CommentGroup;
 	names:Array<Ast.Ident>,
-	type:Expr,
-	values:Array<Expr>,
-	comment:CommentGroup,
-	pos:Int,
-	end:Int,
-};
+	public var type:Expr;
+	public var values:Array<Expr>;
+	public var comment:CommentGroup;
+	public var pos:Int;
+	public var end:Int;
+}
 
-typedef ImplicitType = {
-	name:String,
-	path:String,
-};
+@:structInit
+class ImplicitType {
+	public var name:String;
+	public var path:String;
+}
 
-typedef TypeSpec = {
-	doc:CommentGroup,
-	name:Ident,
-	assign:Pos,
-	type:Expr,
-	comment:CommentGroup,
-	params:FieldList,
+@:structInit
+class TypeSpec {
+	public var doc:CommentGroup;
+	public var name:Ident;
+	public var assign:Pos;
+	public var type:Expr;
+	public var comment:CommentGroup;
+	public var params:FieldList;
 	methods:Array<{
 		name:String,
 		type:ExprType,
 		recv:ExprType,
 		index:Array<Int>
 	}>,
-	pos:Int,
-	end:Int,
-};
+	public var pos:Int;
+	public var end:Int;
+}
 
-typedef BadDecl = {
-	from:Pos,
-	to:Pos,
-};
+@:structInit
+class BadDecl {
+	public var from:Pos;
+	public var to:Pos;
+}
 
-typedef GenDecl = {
-	doc:CommentGroup,
-	tokPos:Pos,
-	tok:Token,
-	lparen:Pos,
-	specs:Array<Spec>,
-	rparen:Pos,
-};
+@:structInit
+class GenDecl {
+	public var doc:CommentGroup;
+	public var tokPos:Pos;
+	public var tok:Token;
+	public var lparen:Pos;
+	public var specs:Array<Spec>;
+	public var rparen:Pos;
+}
 
-typedef FuncDecl = {
-	doc:CommentGroup,
-	recv:FieldList,
-	typeParams:FieldList,
-	name:Ident,
-	type:FuncType,
-	body:BlockStmt,
-	pos:Int,
-	end:Int,
-};
+@:structInit
+class FuncDecl {
+	public var doc:CommentGroup;
+	public var recv:FieldList;
+	public var typeParams:FieldList;
+	public var name:Ident;
+	public var type:FuncType;
+	public var body:BlockStmt;
+	public var pos:Int;
+	public var end:Int;
+}
 
-typedef Object = {
-	kind:ObjKind,
-	name:String,
-	decl:Any,
-	data:Any,
-	type:Any,
-};
+@:structInit
+class Object {
+	public var kind:ObjKind;
+	public var name:String;
+	public var decl:Any;
+	public var data:Any;
+	public var type:Any;
+}
 
-typedef Position = {};
+@:structInit
+class Position {}
+@:structInit
 typedef Pos = Int;
 
 enum abstract Token(String) {

--- a/src/Ast.hx
+++ b/src/Ast.hx
@@ -867,6 +867,48 @@ class FuncDecl {
 	}
 }
 
+/**
+ *Used by `PackageType` to store information about both `FuncDecl`s and `GenDecl`s
+ */
+ @:structInit
+class FuncOrGenDecl {
+	public var id:String;
+
+	//GenDecl
+	public var doc:CommentGroup;
+	public var tokPos:Pos;
+	public var tok:Token;
+	public var lparen:Pos;
+	public var specs:Array<Spec>;
+	public var rparen:Pos;
+
+	//FuncDecl
+	public var recv:FieldList;
+	public var typeParams:FieldList;
+	public var name:Ident;
+	public var type:FuncType;
+	public var body:BlockStmt;
+	public var pos:Int;
+	public var end:Int;
+
+
+	public function new(?doc:CommentGroup, ?tokPos:Pos, ?tok:Token, ?lparen:Pos, ?specs:Array<Spec>, ?rparen:Pos, ?recv:FieldList, ?typeParams:FieldList, ?name:Ident, ?type:FuncType, ?body:BlockStmt, ?pos:Int, ?end:Int) {
+		this.doc = doc;
+		this.tokPos = tokPos;
+		this.tok = tok;
+		this.lparen = lparen;
+		this.specs = specs;
+		this.rparen = rparen;
+		this.recv = recv;
+		this.typeParams = typeParams;
+		this.name = name;
+		this.type = type;
+		this.body = body;
+		this.pos = pos;
+		this.end = end;
+	}
+}
+
 @:structInit
 class Object {
 	public var kind:ObjKind;

--- a/src/Ast.hx
+++ b/src/Ast.hx
@@ -10,6 +10,10 @@ typedef Decl = Dynamic;
 typedef Scope = Dynamic;
 typedef ChanDir = Int;
 
+interface HasDoc {
+	public var doc:CommentGroup;
+}
+
 enum abstract ObjKind(Int) {
 	public final bad = 0; // for error handling
 	public final pkg = 1; // package
@@ -730,7 +734,7 @@ class RangeStmt {
 typedef Spec = Dynamic; // A go interface
 
 @:structInit
-class ImportSpec {
+class ImportSpec implements HasDoc {
 	public var doc:CommentGroup;
 	public var name:String;
 	// Ident
@@ -748,7 +752,7 @@ class ImportSpec {
 }
 
 @:structInit
-class ValueSpec {
+class ValueSpec implements HasDoc {
 	public var doc:CommentGroup;
 	public var names:Array<Ast.Ident>;
 	public var type:Expr;
@@ -780,7 +784,7 @@ class ImplicitType {
 }
 
 @:structInit
-class TypeSpec {
+class TypeSpec implements HasDoc {
 	public var doc:CommentGroup;
 	public var name:Ident;
 	public var assign:Pos;
@@ -826,7 +830,7 @@ class BadDecl {
 }
 
 @:structInit
-class GenDecl {
+class GenDecl implements HasDoc {
 	public var doc:CommentGroup;
 	public var tokPos:Pos;
 	public var tok:Token;
@@ -845,7 +849,7 @@ class GenDecl {
 }
 
 @:structInit
-class FuncDecl {
+class FuncDecl implements HasDoc {
 	public var doc:CommentGroup;
 	public var recv:FieldList;
 	public var typeParams:FieldList;
@@ -871,7 +875,7 @@ class FuncDecl {
  *Used by `PackageType` to store information about both `FuncDecl`s and `GenDecl`s
  */
  @:structInit
-class FuncOrGenDecl {
+class FuncOrGenDecl implements HasDoc {
 	public var id:String;
 
 	//GenDecl

--- a/src/Ast.hx
+++ b/src/Ast.hx
@@ -58,7 +58,10 @@ class BadExpr {
 	public var from:Pos;
 	public var to:Pos;
 
-public function new(?from:Pos, ?to:Pos) {this.from = from;this.to = to;}
+	public function new(?from:Pos, ?to:Pos) {
+		this.from = from;
+		this.to = to;
+	}
 }
 
 @:structInit
@@ -67,7 +70,11 @@ class Ident {
 	public var type:ExprType;
 	public var kind:ObjKind;
 
-public function new(?name:String, ?type:ExprType, ?kind:ObjKind) {this.name = name;this.type = type;this.kind = kind;}
+	public function new(?name:String, ?type:ExprType, ?kind:ObjKind) {
+		this.name = name;
+		this.type = type;
+		this.kind = kind;
+	}
 }
 
 @:structInit
@@ -76,7 +83,10 @@ class Ellipsis {
 	public var ellipsis:Pos;
 	public var elt:Expr;
 
-public function new(?ellipsis:Pos, ?elt:Expr) {this.ellipsis = ellipsis;this.elt = elt;}
+	public function new(?ellipsis:Pos, ?elt:Expr) {
+		this.ellipsis = ellipsis;
+		this.elt = elt;
+	}
 }
 
 @:structInit
@@ -88,7 +98,13 @@ class BasicLit {
 	public var value:String;
 	public var raw:Bool;
 
-public function new(?valuePos:Pos, ?kind:Token, ?type:ExprType, ?value:String, ?raw:Bool) {this.valuePos = valuePos;this.kind = kind;this.type = type;this.value = value;this.raw = raw;}
+	public function new(?valuePos:Pos, ?kind:Token, ?type:ExprType, ?value:String, ?raw:Bool) {
+		this.valuePos = valuePos;
+		this.kind = kind;
+		this.type = type;
+		this.value = value;
+		this.raw = raw;
+	}
 }
 
 @:structInit
@@ -97,7 +113,10 @@ class FuncLit {
 	public var type:FuncType;
 	public var body:BlockStmt;
 
-public function new(?type:FuncType, ?body:BlockStmt) {this.type = type;this.body = body;}
+	public function new(?type:FuncType, ?body:BlockStmt) {
+		this.type = type;
+		this.body = body;
+	}
 }
 
 @:structInit
@@ -109,7 +128,13 @@ class CompositeLit {
 	public var rbrace:Pos;
 	public var incomplete:Bool;
 
-public function new(?type:Expr, ?lbrace:Pos, ?elts:Array<Expr>, ?rbrace:Pos, ?incomplete:Bool) {this.type = type;this.lbrace = lbrace;this.elts = elts;this.rbrace = rbrace;this.incomplete = incomplete;}
+	public function new(?type:Expr, ?lbrace:Pos, ?elts:Array<Expr>, ?rbrace:Pos, ?incomplete:Bool) {
+		this.type = type;
+		this.lbrace = lbrace;
+		this.elts = elts;
+		this.rbrace = rbrace;
+		this.incomplete = incomplete;
+	}
 }
 
 @:structInit
@@ -119,7 +144,11 @@ class ParenExpr {
 	public var x:Expr;
 	public var rparen:Pos;
 
-public function new(?lparen:Pos, ?x:Expr, ?rparen:Pos) {this.lparen = lparen;this.x = x;this.rparen = rparen;}
+	public function new(?lparen:Pos, ?x:Expr, ?rparen:Pos) {
+		this.lparen = lparen;
+		this.x = x;
+		this.rparen = rparen;
+	}
 }
 
 @:structInit
@@ -130,7 +159,12 @@ class SelectorExpr {
 	public var recv:ExprType;
 	public var type:ExprType;
 
-public function new(?x:Expr, ?sel:Ident, ?recv:ExprType, ?type:ExprType) {this.x = x;this.sel = sel;this.recv = recv;this.type = type;}
+	public function new(?x:Expr, ?sel:Ident, ?recv:ExprType, ?type:ExprType) {
+		this.x = x;
+		this.sel = sel;
+		this.recv = recv;
+		this.type = type;
+	}
 }
 
 @:structInit
@@ -142,7 +176,13 @@ class IndexExpr {
 	public var rbrack:Pos;
 	public var type:ExprType;
 
-public function new(?x:Expr, ?lbrack:Pos, ?index:Expr, ?rbrack:Pos, ?type:ExprType) {this.x = x;this.lbrack = lbrack;this.index = index;this.rbrack = rbrack;this.type = type;}
+	public function new(?x:Expr, ?lbrack:Pos, ?index:Expr, ?rbrack:Pos, ?type:ExprType) {
+		this.x = x;
+		this.lbrack = lbrack;
+		this.index = index;
+		this.rbrack = rbrack;
+		this.type = type;
+	}
 }
 
 @:structInit
@@ -153,7 +193,13 @@ class IndexListExpr {
 	public var rbrack:Pos;
 	public var type:ExprType;
 
-public function new(?x:Expr, ?indices:Array<Expr>, ?lbrack:Pos, ?rbrack:Pos, ?type:ExprType) {this.x = x;this.indices = indices;this.lbrack = lbrack;this.rbrack = rbrack;this.type = type;}
+	public function new(?x:Expr, ?indices:Array<Expr>, ?lbrack:Pos, ?rbrack:Pos, ?type:ExprType) {
+		this.x = x;
+		this.indices = indices;
+		this.lbrack = lbrack;
+		this.rbrack = rbrack;
+		this.type = type;
+	}
 }
 
 @:structInit
@@ -168,7 +214,16 @@ class SliceExpr {
 	public var rbrack:Pos;
 	public var type:ExprType;
 
-public function new(?x:Expr, ?lbrack:Pos, ?low:Expr, ?high:Expr, ?max:Expr, ?slice3:Bool, ?rbrack:Pos, ?type:ExprType) {this.x = x;this.lbrack = lbrack;this.low = low;this.high = high;this.max = max;this.slice3 = slice3;this.rbrack = rbrack;this.type = type;}
+	public function new(?x:Expr, ?lbrack:Pos, ?low:Expr, ?high:Expr, ?max:Expr, ?slice3:Bool, ?rbrack:Pos, ?type:ExprType) {
+		this.x = x;
+		this.lbrack = lbrack;
+		this.low = low;
+		this.high = high;
+		this.max = max;
+		this.slice3 = slice3;
+		this.rbrack = rbrack;
+		this.type = type;
+	}
 }
 
 @:structInit
@@ -179,7 +234,12 @@ class TypeAssertExpr {
 	public var type:Expr;
 	public var rparen:Pos;
 
-public function new(?x:Expr, ?lparen:Pos, ?type:Expr, ?rparen:Pos) {this.x = x;this.lparen = lparen;this.type = type;this.rparen = rparen;}
+	public function new(?x:Expr, ?lparen:Pos, ?type:Expr, ?rparen:Pos) {
+		this.x = x;
+		this.lparen = lparen;
+		this.type = type;
+		this.rparen = rparen;
+	}
 }
 
 @:structInit
@@ -192,7 +252,14 @@ class CallExpr {
 	public var rparen:Pos;
 	public var type:ExprType;
 
-public function new(?fun:Expr, ?lparen:Pos, ?args:Array<Expr>, ?ellipsis:Pos, ?rparen:Pos, ?type:ExprType) {this.fun = fun;this.lparen = lparen;this.args = args;this.ellipsis = ellipsis;this.rparen = rparen;this.type = type;}
+	public function new(?fun:Expr, ?lparen:Pos, ?args:Array<Expr>, ?ellipsis:Pos, ?rparen:Pos, ?type:ExprType) {
+		this.fun = fun;
+		this.lparen = lparen;
+		this.args = args;
+		this.ellipsis = ellipsis;
+		this.rparen = rparen;
+		this.type = type;
+	}
 }
 
 @:structInit
@@ -202,7 +269,11 @@ class StarExpr {
 	public var x:Expr;
 	public var type:ExprType;
 
-public function new(?star:Pos, ?x:Expr, ?type:ExprType) {this.star = star;this.x = x;this.type = type;}
+	public function new(?star:Pos, ?x:Expr, ?type:ExprType) {
+		this.star = star;
+		this.x = x;
+		this.type = type;
+	}
 }
 
 @:structInit
@@ -212,7 +283,11 @@ class UnaryExpr {
 	public var op:Token;
 	public var x:Expr;
 
-public function new(?opPos:Pos, ?op:Token, ?x:Expr) {this.opPos = opPos;this.op = op;this.x = x;}
+	public function new(?opPos:Pos, ?op:Token, ?x:Expr) {
+		this.opPos = opPos;
+		this.op = op;
+		this.x = x;
+	}
 }
 
 @:structInit
@@ -224,7 +299,13 @@ class BinaryExpr {
 	public var y:Expr;
 	public var type:ExprType;
 
-public function new(?x:Expr, ?opPos:Pos, ?op:Token, ?y:Expr, ?type:ExprType) {this.x = x;this.opPos = opPos;this.op = op;this.y = y;this.type = type;}
+	public function new(?x:Expr, ?opPos:Pos, ?op:Token, ?y:Expr, ?type:ExprType) {
+		this.x = x;
+		this.opPos = opPos;
+		this.op = op;
+		this.y = y;
+		this.type = type;
+	}
 }
 
 @:structInit
@@ -234,7 +315,11 @@ class KeyValueExpr {
 	public var colon:Pos;
 	public var value:Expr;
 
-public function new(?key:Expr, ?colon:Pos, ?value:Expr) {this.key = key;this.colon = colon;this.value = value;}
+	public function new(?key:Expr, ?colon:Pos, ?value:Expr) {
+		this.key = key;
+		this.colon = colon;
+		this.value = value;
+	}
 }
 
 @:structInit
@@ -245,7 +330,12 @@ class ArrayType {
 	public var elt:Expr;
 	public var type:ExprType;
 
-public function new(?lbrack:Pos, ?len:Expr, ?elt:Expr, ?type:ExprType) {this.lbrack = lbrack;this.len = len;this.elt = elt;this.type = type;}
+	public function new(?lbrack:Pos, ?len:Expr, ?elt:Expr, ?type:ExprType) {
+		this.lbrack = lbrack;
+		this.len = len;
+		this.elt = elt;
+		this.type = type;
+	}
 }
 
 @:structInit
@@ -256,14 +346,21 @@ class StructType {
 	public var incomplete:Bool;
 	public var type:ExprType;
 
-public function new(?struct:Pos, ?fields:FieldList, ?incomplete:Bool, ?type:ExprType) {this.struct = struct;this.fields = fields;this.incomplete = incomplete;this.type = type;}
+	public function new(?struct:Pos, ?fields:FieldList, ?incomplete:Bool, ?type:ExprType) {
+		this.struct = struct;
+		this.fields = fields;
+		this.incomplete = incomplete;
+		this.type = type;
+	}
 }
 
 @:structInit
 class PointerType {
 	public var elem:ExprType;
 
-public function new(?elem:ExprType) {this.elem = elem;}
+	public function new(?elem:ExprType) {
+		this.elem = elem;
+	}
 }
 
 @:structInit
@@ -275,7 +372,13 @@ class FuncType {
 	public var typeParams:FieldList;
 	public var type:ExprType;
 
-public function new(?func:Pos, ?params:FieldList, ?results:FieldList, ?typeParams:FieldList, ?type:ExprType) {this.func = func;this.params = params;this.results = results;this.typeParams = typeParams;this.type = type;}
+	public function new(?func:Pos, ?params:FieldList, ?results:FieldList, ?typeParams:FieldList, ?type:ExprType) {
+		this.func = func;
+		this.params = params;
+		this.results = results;
+		this.typeParams = typeParams;
+		this.type = type;
+	}
 }
 
 @:structInit
@@ -287,7 +390,12 @@ class InterfaceType {
 	public var incomplete:Bool;
 	public var type:ExprType;
 
-public function new(?interfacePos:Pos, ?methods:FieldList, ?incomplete:Bool, ?type:ExprType) {this.interfacePos = interfacePos;this.methods = methods;this.incomplete = incomplete;this.type = type;}
+	public function new(?interfacePos:Pos, ?methods:FieldList, ?incomplete:Bool, ?type:ExprType) {
+		this.interfacePos = interfacePos;
+		this.methods = methods;
+		this.incomplete = incomplete;
+		this.type = type;
+	}
 }
 
 @:structInit
@@ -298,7 +406,12 @@ class MapType {
 	public var value:Expr;
 	public var type:ExprType;
 
-public function new(?map:Pos, ?key:Expr, ?value:Expr, ?type:ExprType) {this.map = map;this.key = key;this.value = value;this.type = type;}
+	public function new(?map:Pos, ?key:Expr, ?value:Expr, ?type:ExprType) {
+		this.map = map;
+		this.key = key;
+		this.value = value;
+		this.type = type;
+	}
 }
 
 @:structInit
@@ -310,7 +423,13 @@ class ChanType {
 	public var value:Expr;
 	public var type:ExprType;
 
-public function new(?begin:Pos, ?arrow:Pos, ?dir:ChanDir, ?value:Expr, ?type:ExprType) {this.begin = begin;this.arrow = arrow;this.dir = dir;this.value = value;this.type = type;}
+	public function new(?begin:Pos, ?arrow:Pos, ?dir:ChanDir, ?value:Expr, ?type:ExprType) {
+		this.begin = begin;
+		this.arrow = arrow;
+		this.dir = dir;
+		this.value = value;
+		this.type = type;
+	}
 }
 
 @:structInit
@@ -319,7 +438,10 @@ class BadStmt {
 	public var from:Pos;
 	public var to:Pos;
 
-public function new(?from:Pos, ?to:Pos) {this.from = from;this.to = to;}
+	public function new(?from:Pos, ?to:Pos) {
+		this.from = from;
+		this.to = to;
+	}
 }
 
 @:structInit
@@ -327,7 +449,9 @@ class DeclStmt {
 	// > Node,
 	public var decl:Decl;
 
-public function new(?decl:Decl) {this.decl = decl;}
+	public function new(?decl:Decl) {
+		this.decl = decl;
+	}
 }
 
 @:structInit
@@ -336,7 +460,10 @@ class EmptyStmt {
 	public var semicolon:Pos;
 	public var implicit:Bool;
 
-public function new(?semicolon:Pos, ?implicit:Bool) {this.semicolon = semicolon;this.implicit = implicit;}
+	public function new(?semicolon:Pos, ?implicit:Bool) {
+		this.semicolon = semicolon;
+		this.implicit = implicit;
+	}
 }
 
 @:structInit
@@ -346,7 +473,11 @@ class LabeledStmt {
 	public var colon:Pos;
 	public var stmt:Stmt;
 
-public function new(?label:Ident, ?colon:Pos, ?stmt:Stmt) {this.label = label;this.colon = colon;this.stmt = stmt;}
+	public function new(?label:Ident, ?colon:Pos, ?stmt:Stmt) {
+		this.label = label;
+		this.colon = colon;
+		this.stmt = stmt;
+	}
 }
 
 @:structInit
@@ -356,7 +487,11 @@ class ExprStmt {
 	public var end:Int;
 	public var pos:Int;
 
-public function new(?x:Expr, ?end:Int, ?pos:Int) {this.x = x;this.end = end;this.pos = pos;}
+	public function new(?x:Expr, ?end:Int, ?pos:Int) {
+		this.x = x;
+		this.end = end;
+		this.pos = pos;
+	}
 }
 
 @:structInit
@@ -366,7 +501,11 @@ class SendStmt {
 	public var arrow:Pos;
 	public var value:Expr;
 
-public function new(?chan:Expr, ?arrow:Pos, ?value:Expr) {this.chan = chan;this.arrow = arrow;this.value = value;}
+	public function new(?chan:Expr, ?arrow:Pos, ?value:Expr) {
+		this.chan = chan;
+		this.arrow = arrow;
+		this.value = value;
+	}
 }
 
 @:structInit
@@ -376,7 +515,11 @@ class IncDecStmt {
 	public var tokPos:Pos;
 	public var tok:Token;
 
-public function new(?x:Expr, ?tokPos:Pos, ?tok:Token) {this.x = x;this.tokPos = tokPos;this.tok = tok;}
+	public function new(?x:Expr, ?tokPos:Pos, ?tok:Token) {
+		this.x = x;
+		this.tokPos = tokPos;
+		this.tok = tok;
+	}
 }
 
 @:structInit
@@ -387,7 +530,12 @@ class AssignStmt {
 	public var tok:Token;
 	public var rhs:Array<Expr>;
 
-public function new(?lhs:Array<Expr>, ?tokPos:Pos, ?tok:Token, ?rhs:Array<Expr>) {this.lhs = lhs;this.tokPos = tokPos;this.tok = tok;this.rhs = rhs;}
+	public function new(?lhs:Array<Expr>, ?tokPos:Pos, ?tok:Token, ?rhs:Array<Expr>) {
+		this.lhs = lhs;
+		this.tokPos = tokPos;
+		this.tok = tok;
+		this.rhs = rhs;
+	}
 }
 
 @:structInit
@@ -396,7 +544,10 @@ class GoStmt {
 	public var go:Pos;
 	public var call:CallExpr;
 
-public function new(?go:Pos, ?call:CallExpr) {this.go = go;this.call = call;}
+	public function new(?go:Pos, ?call:CallExpr) {
+		this.go = go;
+		this.call = call;
+	}
 }
 
 @:structInit
@@ -405,7 +556,10 @@ class DeferStmt {
 	public var defer:Pos;
 	public var call:CallExpr;
 
-public function new(?defer:Pos, ?call:CallExpr) {this.defer = defer;this.call = call;}
+	public function new(?defer:Pos, ?call:CallExpr) {
+		this.defer = defer;
+		this.call = call;
+	}
 }
 
 @:structInit
@@ -415,7 +569,10 @@ class ReturnStmt {
 	// return TODO: return -> returnPos
 	public var results:Array<Expr>;
 
-public function new(?returnPos:Pos, ?results:Array<Expr>) {this.returnPos = returnPos;this.results = results;}
+	public function new(?returnPos:Pos, ?results:Array<Expr>) {
+		this.returnPos = returnPos;
+		this.results = results;
+	}
 }
 
 @:structInit
@@ -424,7 +581,11 @@ class BranchStmt {
 	public var tok:Token;
 	public var label:Ident;
 
-public function new(?tokPos:Pos, ?tok:Token, ?label:Ident) {this.tokPos = tokPos;this.tok = tok;this.label = label;}
+	public function new(?tokPos:Pos, ?tok:Token, ?label:Ident) {
+		this.tokPos = tokPos;
+		this.tok = tok;
+		this.label = label;
+	}
 }
 
 @:structInit
@@ -433,7 +594,11 @@ class BlockStmt {
 	public var list:Array<Stmt>;
 	public var rbrace:Pos;
 
-public function new(?lbrace:Pos, ?list:Array<Stmt>, ?rbrace:Pos) {this.lbrace = lbrace;this.list = list;this.rbrace = rbrace;}
+	public function new(?lbrace:Pos, ?list:Array<Stmt>, ?rbrace:Pos) {
+		this.lbrace = lbrace;
+		this.list = list;
+		this.rbrace = rbrace;
+	}
 }
 
 @:structInit
@@ -455,7 +620,12 @@ class CaseClause {
 	public var colon:Pos;
 	public var body:Array<Stmt>;
 
-public function new(?casePos:Pos, ?list:Array<Expr>, ?colon:Pos, ?body:Array<Stmt>) {this.casePos = casePos;this.list = list;this.colon = colon;this.body = body;}
+	public function new(?casePos:Pos, ?list:Array<Expr>, ?colon:Pos, ?body:Array<Stmt>) {
+		this.casePos = casePos;
+		this.list = list;
+		this.colon = colon;
+		this.body = body;
+	}
 }
 
 @:structInit
@@ -466,7 +636,12 @@ class SwitchStmt {
 	public var tag:Expr;
 	public var body:BlockStmt;
 
-public function new(?switchPos:Pos, ?init:Stmt, ?tag:Expr, ?body:BlockStmt) {this.switchPos = switchPos;this.init = init;this.tag = tag;this.body = body;}
+	public function new(?switchPos:Pos, ?init:Stmt, ?tag:Expr, ?body:BlockStmt) {
+		this.switchPos = switchPos;
+		this.init = init;
+		this.tag = tag;
+		this.body = body;
+	}
 }
 
 @:structInit
@@ -477,7 +652,12 @@ class TypeSwitchStmt {
 	public var assign:Stmt;
 	public var body:BlockStmt;
 
-public function new(?switchPos:Pos, ?init:Stmt, ?assign:Stmt, ?body:BlockStmt) {this.switchPos = switchPos;this.init = init;this.assign = assign;this.body = body;}
+	public function new(?switchPos:Pos, ?init:Stmt, ?assign:Stmt, ?body:BlockStmt) {
+		this.switchPos = switchPos;
+		this.init = init;
+		this.assign = assign;
+		this.body = body;
+	}
 }
 
 @:structInit
@@ -488,7 +668,12 @@ class CommClause {
 	public var colon:Pos;
 	public var body:Array<Stmt>;
 
-public function new(?casePos:Pos, ?comm:Stmt, ?colon:Pos, ?body:Array<Stmt>) {this.casePos = casePos;this.comm = comm;this.colon = colon;this.body = body;}
+	public function new(?casePos:Pos, ?comm:Stmt, ?colon:Pos, ?body:Array<Stmt>) {
+		this.casePos = casePos;
+		this.comm = comm;
+		this.colon = colon;
+		this.body = body;
+	}
 }
 
 @:structInit
@@ -496,7 +681,10 @@ class SelectStmt {
 	public var select:Pos;
 	public var body:BlockStmt;
 
-public function new(?select:Pos, ?body:BlockStmt) {this.select = select;this.body = body;}
+	public function new(?select:Pos, ?body:BlockStmt) {
+		this.select = select;
+		this.body = body;
+	}
 }
 
 @:structInit
@@ -508,7 +696,13 @@ class ForStmt {
 	public var post:Stmt;
 	public var body:BlockStmt;
 
-public function new(?forPos:Pos, ?init:Stmt, ?cond:Expr, ?post:Stmt, ?body:BlockStmt) {this.forPos = forPos;this.init = init;this.cond = cond;this.post = post;this.body = body;}
+	public function new(?forPos:Pos, ?init:Stmt, ?cond:Expr, ?post:Stmt, ?body:BlockStmt) {
+		this.forPos = forPos;
+		this.init = init;
+		this.cond = cond;
+		this.post = post;
+		this.body = body;
+	}
 }
 
 @:structInit
@@ -522,7 +716,15 @@ class RangeStmt {
 	public var x:Expr;
 	public var body:BlockStmt;
 
-public function new(?forPos:Pos, ?key:Expr, ?value:Expr, ?tokPos:Pos, ?tok:Token, ?x:Expr, ?body:BlockStmt) {this.forPos = forPos;this.key = key;this.value = value;this.tokPos = tokPos;this.tok = tok;this.x = x;this.body = body;}
+	public function new(?forPos:Pos, ?key:Expr, ?value:Expr, ?tokPos:Pos, ?tok:Token, ?x:Expr, ?body:BlockStmt) {
+		this.forPos = forPos;
+		this.key = key;
+		this.value = value;
+		this.tokPos = tokPos;
+		this.tok = tok;
+		this.x = x;
+		this.body = body;
+	}
 }
 
 typedef Spec = Dynamic; // A go interface
@@ -536,7 +738,13 @@ class ImportSpec {
 	public var comment:CommentGroup;
 	public var endPos:Pos;
 
-public function new(?doc:CommentGroup, ?name:String, ?path:String, ?comment:CommentGroup, ?endPos:Pos) {this.doc = doc;this.name = name;this.path = path;this.comment = comment;this.endPos = endPos;}
+	public function new(?doc:CommentGroup, ?name:String, ?path:String, ?comment:CommentGroup, ?endPos:Pos) {
+		this.doc = doc;
+		this.name = name;
+		this.path = path;
+		this.comment = comment;
+		this.endPos = endPos;
+	}
 }
 
 @:structInit
@@ -549,15 +757,26 @@ class ValueSpec {
 	public var pos:Int;
 	public var end:Int;
 
-public function new(?doc:CommentGroup, ?names:Array<Ast.Ident>, ?type:Expr, ?values:Array<Expr>, ?comment:CommentGroup, ?pos:Int, ?end:Int) {this.doc = doc;this.names = names;this.type = type;this.values = values;this.comment = comment;this.pos = pos;this.end = end;}
-} 
+	public function new(?doc:CommentGroup, ?names:Array<Ast.Ident>, ?type:Expr, ?values:Array<Expr>, ?comment:CommentGroup, ?pos:Int, ?end:Int) {
+		this.doc = doc;
+		this.names = names;
+		this.type = type;
+		this.values = values;
+		this.comment = comment;
+		this.pos = pos;
+		this.end = end;
+	}
+}
 
 @:structInit
 class ImplicitType {
 	public var name:String;
 	public var path:String;
 
-public function new(?name:String, ?path:String) {this.name = name;this.path = path;}
+	public function new(?name:String, ?path:String) {
+		this.name = name;
+		this.path = path;
+	}
 }
 
 @:structInit
@@ -568,11 +787,31 @@ class TypeSpec {
 	public var type:Expr;
 	public var comment:CommentGroup;
 	public var params:FieldList;
-	public var methods:Array<{name:String,type:ExprType,recv:ExprType,index:Array<Int>}>;
+	public var methods:Array<{
+		name:String,
+		type:ExprType,
+		recv:ExprType,
+		index:Array<Int>
+	}>;
 	public var pos:Int;
 	public var end:Int;
 
-public function new(?doc:CommentGroup, ?name:Ident, ?assign:Pos, ?type:Expr, ?comment:CommentGroup, ?params:FieldList, ?methods:Array<{name:String,type:ExprType,recv:ExprType,index:Array<Int>}>, ?pos:Int, ?end:Int) {this.doc = doc;this.name = name;this.assign = assign;this.type = type;this.comment = comment;this.params = params;this.methods = methods;this.pos = pos;this.end = end;}
+	public function new(?doc:CommentGroup, ?name:Ident, ?assign:Pos, ?type:Expr, ?comment:CommentGroup, ?params:FieldList, ?methods:Array<{
+		name:String,
+		type:ExprType,
+		recv:ExprType,
+		index:Array<Int>
+	}>, ?pos:Int, ?end:Int) {
+		this.doc = doc;
+		this.name = name;
+		this.assign = assign;
+		this.type = type;
+		this.comment = comment;
+		this.params = params;
+		this.methods = methods;
+		this.pos = pos;
+		this.end = end;
+	}
 }
 
 @:structInit
@@ -580,7 +819,10 @@ class BadDecl {
 	public var from:Pos;
 	public var to:Pos;
 
-public function new(?from:Pos, ?to:Pos) {this.from = from;this.to = to;}
+	public function new(?from:Pos, ?to:Pos) {
+		this.from = from;
+		this.to = to;
+	}
 }
 
 @:structInit
@@ -592,7 +834,14 @@ class GenDecl {
 	public var specs:Array<Spec>;
 	public var rparen:Pos;
 
-public function new(?doc:CommentGroup, ?tokPos:Pos, ?tok:Token, ?lparen:Pos, ?specs:Array<Spec>, ?rparen:Pos) {this.doc = doc;this.tokPos = tokPos;this.tok = tok;this.lparen = lparen;this.specs = specs;this.rparen = rparen;}
+	public function new(?doc:CommentGroup, ?tokPos:Pos, ?tok:Token, ?lparen:Pos, ?specs:Array<Spec>, ?rparen:Pos) {
+		this.doc = doc;
+		this.tokPos = tokPos;
+		this.tok = tok;
+		this.lparen = lparen;
+		this.specs = specs;
+		this.rparen = rparen;
+	}
 }
 
 @:structInit
@@ -606,7 +855,16 @@ class FuncDecl {
 	public var pos:Int;
 	public var end:Int;
 
-public function new(?doc:CommentGroup, ?recv:FieldList, ?typeParams:FieldList, ?name:Ident, ?type:FuncType, ?body:BlockStmt, ?pos:Int, ?end:Int) {this.doc = doc;this.recv = recv;this.typeParams = typeParams;this.name = name;this.type = type;this.body = body;this.pos = pos;this.end = end;}
+	public function new(?doc:CommentGroup, ?recv:FieldList, ?typeParams:FieldList, ?name:Ident, ?type:FuncType, ?body:BlockStmt, ?pos:Int, ?end:Int) {
+		this.doc = doc;
+		this.recv = recv;
+		this.typeParams = typeParams;
+		this.name = name;
+		this.type = type;
+		this.body = body;
+		this.pos = pos;
+		this.end = end;
+	}
 }
 
 @:structInit
@@ -617,7 +875,13 @@ class Object {
 	public var data:Any;
 	public var type:Any;
 
-public function new(?kind:ObjKind, ?name:String, ?decl:Any, ?data:Any, ?type:Any) {this.kind = kind;this.name = name;this.decl = decl;this.data = data;this.type = type;}
+	public function new(?kind:ObjKind, ?name:String, ?decl:Any, ?data:Any, ?type:Any) {
+		this.kind = kind;
+		this.name = name;
+		this.decl = decl;
+		this.data = data;
+		this.type = type;
+	}
 }
 
 @:structInit
@@ -625,7 +889,6 @@ class Position {}
 
 @:structInit
 typedef Pos = Int;
-
 
 enum abstract Token(String) {
 	public final ILLEGAL = "ILLEGAL";

--- a/src/Ast.hx
+++ b/src/Ast.hx
@@ -47,6 +47,14 @@ class Field {
 	public var type:Expr;
 	public var tag:String;
 	public var comment:CommentGroup;
+
+	public function new(doc:CommentGroup, names:Array<Ident>, type:Expr, tag:String, comment:CommentGroup) {
+		this.doc = doc;
+		this.names = names;
+		this.type = type;
+		this.tag = tag;
+		this.comment = comment
+	}
 }
 
 @:structInit
@@ -54,20 +62,26 @@ class FieldList {
 	public var opening:Pos;
 	public var list:Array<Field>;
 	public var closing:Pos;
-}
+
+public function new() {}
 
 @:structInit
 class BadExpr {
 	// > Node,
 	public var from:Pos;
 	public var to:Pos;
+
+	public function new() {}
 }
 
 @:structInit
 class Ident {
 	public var name:String;
 	public var type:ExprType;
-	?public var kind:ObjKind;
+	?
+	public var kind:ObjKind;
+
+	public function new() {}
 }
 
 @:structInit
@@ -75,6 +89,8 @@ class Ellipsis {
 	// > Node,
 	public var ellipsis:Pos;
 	public var elt:Expr;
+
+	public function new() {}
 }
 
 @:structInit
@@ -85,6 +101,8 @@ class BasicLit {
 	public var type:ExprType;
 	public var value:String;
 	public var raw:Bool;
+
+	public function new() {}
 }
 
 @:structInit
@@ -92,6 +110,8 @@ class FuncLit {
 	// > Node,
 	public var type:FuncType;
 	public var body:BlockStmt;
+
+	public function new() {}
 }
 
 @:structInit
@@ -102,6 +122,8 @@ class CompositeLit {
 	public var elts:Array<Expr>;
 	public var rbrace:Pos;
 	public var incomplete:Bool;
+
+	public function new() {}
 }
 
 @:structInit
@@ -110,6 +132,8 @@ class ParenExpr {
 	public var lparen:Pos;
 	public var x:Expr;
 	public var rparen:Pos;
+
+	public function new() {}
 }
 
 @:structInit
@@ -119,6 +143,8 @@ class SelectorExpr {
 	public var sel:Ident;
 	public var recv:ExprType;
 	public var type:ExprType;
+
+	public function new() {}
 }
 
 @:structInit
@@ -129,6 +155,8 @@ class IndexExpr {
 	public var index:Expr;
 	public var rbrack:Pos;
 	public var type:ExprType;
+
+	public function new() {}
 }
 
 @:structInit
@@ -138,6 +166,8 @@ class IndexListExpr {
 	public var lbrack:Pos;
 	public var rbrack:Pos;
 	public var type:ExprType;
+
+	public function new() {}
 }
 
 @:structInit
@@ -151,6 +181,8 @@ class SliceExpr {
 	public var slice3:Bool;
 	public var rbrack:Pos;
 	public var type:ExprType;
+
+	public function new() {}
 }
 
 @:structInit
@@ -160,6 +192,8 @@ class TypeAssertExpr {
 	public var lparen:Pos;
 	public var type:Expr;
 	public var rparen:Pos;
+
+	public function new() {}
 }
 
 @:structInit
@@ -171,6 +205,8 @@ class CallExpr {
 	public var ellipsis:Pos;
 	public var rparen:Pos;
 	public var type:ExprType;
+
+	public function new() {}
 }
 
 @:structInit
@@ -179,6 +215,8 @@ class StarExpr {
 	public var star:Pos;
 	public var x:Expr;
 	public var type:ExprType;
+
+	public function new() {}
 }
 
 @:structInit
@@ -187,6 +225,8 @@ class UnaryExpr {
 	public var opPos:Pos;
 	public var op:Token;
 	public var x:Expr;
+
+	public function new() {}
 }
 
 @:structInit
@@ -197,6 +237,8 @@ class BinaryExpr {
 	public var op:Token;
 	public var y:Expr;
 	public var type:ExprType;
+
+	public function new() {}
 }
 
 @:structInit
@@ -205,6 +247,8 @@ class KeyValueExpr {
 	public var key:Expr;
 	public var colon:Pos;
 	public var value:Expr;
+
+	public function new() {}
 }
 
 @:structInit
@@ -214,6 +258,8 @@ class ArrayType {
 	public var len:Expr;
 	public var elt:Expr;
 	public var type:ExprType;
+
+	public function new() {}
 }
 
 @:structInit
@@ -223,11 +269,15 @@ class StructType {
 	public var fields:FieldList;
 	public var incomplete:Bool;
 	public var type:ExprType;
+
+	public function new() {}
 }
 
 @:structInit
 class PointerType {
 	public var elem:ExprType;
+
+	public function new() {}
 }
 
 @:structInit
@@ -238,6 +288,8 @@ class FuncType {
 	public var results:FieldList;
 	public var typeParams:FieldList;
 	public var type:ExprType;
+
+	public function new() {}
 }
 
 @:structInit
@@ -248,6 +300,8 @@ class InterfaceType {
 	public var methods:FieldList;
 	public var incomplete:Bool;
 	public var type:ExprType;
+
+	public function new() {}
 }
 
 @:structInit
@@ -257,6 +311,8 @@ class MapType {
 	public var key:Expr;
 	public var value:Expr;
 	public var type:ExprType;
+
+	public function new() {}
 }
 
 @:structInit
@@ -267,6 +323,8 @@ class ChanType {
 	public var dir:ChanDir;
 	public var value:Expr;
 	public var type:ExprType;
+
+	public function new() {}
 }
 
 @:structInit
@@ -274,12 +332,16 @@ class BadStmt {
 	// > Node,
 	public var from:Pos;
 	public var to:Pos;
+
+	public function new() {}
 }
 
 @:structInit
 class DeclStmt {
 	// > Node,
 	public var decl:Decl;
+
+	public function new() {}
 }
 
 @:structInit
@@ -287,6 +349,8 @@ class EmptyStmt {
 	// > Node,
 	public var semicolon:Pos;
 	public var implicit:Bool;
+
+	public function new() {}
 }
 
 @:structInit
@@ -295,6 +359,8 @@ class LabeledStmt {
 	public var label:Ident;
 	public var colon:Pos;
 	public var stmt:Stmt;
+
+	public function new() {}
 }
 
 @:structInit
@@ -303,6 +369,8 @@ class ExprStmt {
 	public var x:Expr;
 	public var end:Int;
 	public var pos:Int;
+
+	public function new() {}
 }
 
 @:structInit
@@ -311,6 +379,8 @@ class SendStmt {
 	public var chan:Expr;
 	public var arrow:Pos;
 	public var value:Expr;
+
+	public function new() {}
 }
 
 @:structInit
@@ -319,6 +389,8 @@ class IncDecStmt {
 	public var x:Expr;
 	public var tokPos:Pos;
 	public var tok:Token;
+
+	public function new() {}
 }
 
 @:structInit
@@ -328,6 +400,8 @@ class AssignStmt {
 	public var tokPos:Pos;
 	public var tok:Token;
 	public var rhs:Array<Expr>;
+
+	public function new() {}
 }
 
 @:structInit
@@ -335,6 +409,8 @@ class GoStmt {
 	// > Node,
 	public var go:Pos;
 	public var call:CallExpr;
+
+	public function new() {}
 }
 
 @:structInit
@@ -342,6 +418,8 @@ class DeferStmt {
 	// > Node,
 	public var defer:Pos;
 	public var call:CallExpr;
+
+	public function new() {}
 }
 
 @:structInit
@@ -350,6 +428,8 @@ class ReturnStmt {
 	public var returnPos:Pos;
 	// return TODO: return -> returnPos
 	public var results:Array<Expr>;
+
+	public function new() {}
 }
 
 @:structInit
@@ -357,6 +437,8 @@ class BranchStmt {
 	public var tokPos:Pos;
 	public var tok:Token;
 	public var label:Ident;
+
+	public function new() {}
 }
 
 @:structInit
@@ -364,6 +446,8 @@ class BlockStmt {
 	public var lbrace:Pos;
 	public var list:Array<Stmt>;
 	public var rbrace:Pos;
+
+	public function new() {}
 }
 
 @:structInit
@@ -384,6 +468,8 @@ class CaseClause {
 	public var list:Array<Expr>;
 	public var colon:Pos;
 	public var body:Array<Stmt>;
+
+	public function new() {}
 }
 
 @:structInit
@@ -393,6 +479,8 @@ class SwitchStmt {
 	public var init:Stmt;
 	public var tag:Expr;
 	public var body:BlockStmt;
+
+	public function new() {}
 }
 
 @:structInit
@@ -402,6 +490,8 @@ class TypeSwitchStmt {
 	public var init:Stmt;
 	public var assign:Stmt;
 	public var body:BlockStmt;
+
+	public function new() {}
 }
 
 @:structInit
@@ -411,12 +501,16 @@ class CommClause {
 	public var comm:Stmt;
 	public var colon:Pos;
 	public var body:Array<Stmt>;
+
+	public function new() {}
 }
 
 @:structInit
 class SelectStmt {
 	public var select:Pos;
 	public var body:BlockStmt;
+
+	public function new() {}
 }
 
 @:structInit
@@ -427,6 +521,8 @@ class ForStmt {
 	public var cond:Expr;
 	public var post:Stmt;
 	public var body:BlockStmt;
+
+	public function new() {}
 }
 
 @:structInit
@@ -439,6 +535,8 @@ class RangeStmt {
 	public var tok:Token;
 	public var x:Expr;
 	public var body:BlockStmt;
+
+	public function new() {}
 }
 
 typedef Spec = Dynamic; // A go interface
@@ -451,23 +549,27 @@ class ImportSpec {
 	public var path:String;
 	public var comment:CommentGroup;
 	public var endPos:Pos;
+
+	public function new() {}
 }
 
 @:structInit
 class ValueSpec {
 	public var doc:CommentGroup;
-	names:Array<Ast.Ident>,
-	public var type:Expr;
-	public var values:Array<Expr>;
-	public var comment:CommentGroup;
-	public var pos:Int;
-	public var end:Int;
-}
+	names:Array<Ast.Ident>
+, public var type:Expr;
+public var values:Array<Expr>;
+public var comment:CommentGroup;
+public var pos:Int;
+public var end:Int;
 
-@:structInit
+	public function new() {}
+} @:structInit
 class ImplicitType {
 	public var name:String;
 	public var path:String;
+
+	public function new() {}
 }
 
 @:structInit
@@ -483,15 +585,17 @@ class TypeSpec {
 		type:ExprType,
 		recv:ExprType,
 		index:Array<Int>
-	}>,
-	public var pos:Int;
-	public var end:Int;
-}
+	}>
+, public var pos:Int;
+public var end:Int;
 
-@:structInit
+	public function new() {}
+} @:structInit
 class BadDecl {
 	public var from:Pos;
 	public var to:Pos;
+
+	public function new() {}
 }
 
 @:structInit
@@ -502,6 +606,8 @@ class GenDecl {
 	public var lparen:Pos;
 	public var specs:Array<Spec>;
 	public var rparen:Pos;
+
+	public function new() {}
 }
 
 @:structInit
@@ -514,6 +620,8 @@ class FuncDecl {
 	public var body:BlockStmt;
 	public var pos:Int;
 	public var end:Int;
+
+	public function new() {}
 }
 
 @:structInit
@@ -523,10 +631,13 @@ class Object {
 	public var decl:Any;
 	public var data:Any;
 	public var type:Any;
+
+	public function new() {}
 }
 
 @:structInit
 class Position {}
+
 @:structInit
 typedef Pos = Int;
 

--- a/src/Ast.hx
+++ b/src/Ast.hx
@@ -63,7 +63,12 @@ class FieldList {
 	public var list:Array<Field>;
 	public var closing:Pos;
 
-public function new() {}
+	public function new(opening:Pos, list:Array<Field>, closing:Pos) {
+		this.opening = opening;
+		this.list = list;
+		this.closing = closing;
+	}
+}
 
 @:structInit
 class BadExpr {

--- a/src/Ast.hx
+++ b/src/Ast.hx
@@ -34,10 +34,6 @@ class Comment {
 @:structInit
 class CommentGroup {
 	public var list:Array<Comment>;
-
-	public function new(list:Array<Comment>) {
-		this.list = list;
-	}
 }
 
 @:structInit
@@ -47,14 +43,6 @@ class Field {
 	public var type:Expr;
 	public var tag:String;
 	public var comment:CommentGroup;
-
-	public function new(doc:CommentGroup, names:Array<Ident>, type:Expr, tag:String, comment:CommentGroup) {
-		this.doc = doc;
-		this.names = names;
-		this.type = type;
-		this.tag = tag;
-		this.comment = comment
-	}
 }
 
 @:structInit
@@ -62,12 +50,6 @@ class FieldList {
 	public var opening:Pos;
 	public var list:Array<Field>;
 	public var closing:Pos;
-
-	public function new(opening:Pos, list:Array<Field>, closing:Pos) {
-		this.opening = opening;
-		this.list = list;
-		this.closing = closing;
-	}
 }
 
 @:structInit
@@ -76,17 +58,16 @@ class BadExpr {
 	public var from:Pos;
 	public var to:Pos;
 
-	public function new() {}
+public function new(?from:Pos, ?to:Pos) {this.from = from;this.to = to;}
 }
 
 @:structInit
 class Ident {
 	public var name:String;
 	public var type:ExprType;
-	?
 	public var kind:ObjKind;
 
-	public function new() {}
+public function new(?name:String, ?type:ExprType, ?kind:ObjKind) {this.name = name;this.type = type;this.kind = kind;}
 }
 
 @:structInit
@@ -95,7 +76,7 @@ class Ellipsis {
 	public var ellipsis:Pos;
 	public var elt:Expr;
 
-	public function new() {}
+public function new(?ellipsis:Pos, ?elt:Expr) {this.ellipsis = ellipsis;this.elt = elt;}
 }
 
 @:structInit
@@ -107,7 +88,7 @@ class BasicLit {
 	public var value:String;
 	public var raw:Bool;
 
-	public function new() {}
+public function new(?valuePos:Pos, ?kind:Token, ?type:ExprType, ?value:String, ?raw:Bool) {this.valuePos = valuePos;this.kind = kind;this.type = type;this.value = value;this.raw = raw;}
 }
 
 @:structInit
@@ -116,7 +97,7 @@ class FuncLit {
 	public var type:FuncType;
 	public var body:BlockStmt;
 
-	public function new() {}
+public function new(?type:FuncType, ?body:BlockStmt) {this.type = type;this.body = body;}
 }
 
 @:structInit
@@ -128,7 +109,7 @@ class CompositeLit {
 	public var rbrace:Pos;
 	public var incomplete:Bool;
 
-	public function new() {}
+public function new(?type:Expr, ?lbrace:Pos, ?elts:Array<Expr>, ?rbrace:Pos, ?incomplete:Bool) {this.type = type;this.lbrace = lbrace;this.elts = elts;this.rbrace = rbrace;this.incomplete = incomplete;}
 }
 
 @:structInit
@@ -138,7 +119,7 @@ class ParenExpr {
 	public var x:Expr;
 	public var rparen:Pos;
 
-	public function new() {}
+public function new(?lparen:Pos, ?x:Expr, ?rparen:Pos) {this.lparen = lparen;this.x = x;this.rparen = rparen;}
 }
 
 @:structInit
@@ -149,7 +130,7 @@ class SelectorExpr {
 	public var recv:ExprType;
 	public var type:ExprType;
 
-	public function new() {}
+public function new(?x:Expr, ?sel:Ident, ?recv:ExprType, ?type:ExprType) {this.x = x;this.sel = sel;this.recv = recv;this.type = type;}
 }
 
 @:structInit
@@ -161,7 +142,7 @@ class IndexExpr {
 	public var rbrack:Pos;
 	public var type:ExprType;
 
-	public function new() {}
+public function new(?x:Expr, ?lbrack:Pos, ?index:Expr, ?rbrack:Pos, ?type:ExprType) {this.x = x;this.lbrack = lbrack;this.index = index;this.rbrack = rbrack;this.type = type;}
 }
 
 @:structInit
@@ -172,7 +153,7 @@ class IndexListExpr {
 	public var rbrack:Pos;
 	public var type:ExprType;
 
-	public function new() {}
+public function new(?x:Expr, ?indices:Array<Expr>, ?lbrack:Pos, ?rbrack:Pos, ?type:ExprType) {this.x = x;this.indices = indices;this.lbrack = lbrack;this.rbrack = rbrack;this.type = type;}
 }
 
 @:structInit
@@ -187,7 +168,7 @@ class SliceExpr {
 	public var rbrack:Pos;
 	public var type:ExprType;
 
-	public function new() {}
+public function new(?x:Expr, ?lbrack:Pos, ?low:Expr, ?high:Expr, ?max:Expr, ?slice3:Bool, ?rbrack:Pos, ?type:ExprType) {this.x = x;this.lbrack = lbrack;this.low = low;this.high = high;this.max = max;this.slice3 = slice3;this.rbrack = rbrack;this.type = type;}
 }
 
 @:structInit
@@ -198,7 +179,7 @@ class TypeAssertExpr {
 	public var type:Expr;
 	public var rparen:Pos;
 
-	public function new() {}
+public function new(?x:Expr, ?lparen:Pos, ?type:Expr, ?rparen:Pos) {this.x = x;this.lparen = lparen;this.type = type;this.rparen = rparen;}
 }
 
 @:structInit
@@ -211,7 +192,7 @@ class CallExpr {
 	public var rparen:Pos;
 	public var type:ExprType;
 
-	public function new() {}
+public function new(?fun:Expr, ?lparen:Pos, ?args:Array<Expr>, ?ellipsis:Pos, ?rparen:Pos, ?type:ExprType) {this.fun = fun;this.lparen = lparen;this.args = args;this.ellipsis = ellipsis;this.rparen = rparen;this.type = type;}
 }
 
 @:structInit
@@ -221,7 +202,7 @@ class StarExpr {
 	public var x:Expr;
 	public var type:ExprType;
 
-	public function new() {}
+public function new(?star:Pos, ?x:Expr, ?type:ExprType) {this.star = star;this.x = x;this.type = type;}
 }
 
 @:structInit
@@ -231,7 +212,7 @@ class UnaryExpr {
 	public var op:Token;
 	public var x:Expr;
 
-	public function new() {}
+public function new(?opPos:Pos, ?op:Token, ?x:Expr) {this.opPos = opPos;this.op = op;this.x = x;}
 }
 
 @:structInit
@@ -243,7 +224,7 @@ class BinaryExpr {
 	public var y:Expr;
 	public var type:ExprType;
 
-	public function new() {}
+public function new(?x:Expr, ?opPos:Pos, ?op:Token, ?y:Expr, ?type:ExprType) {this.x = x;this.opPos = opPos;this.op = op;this.y = y;this.type = type;}
 }
 
 @:structInit
@@ -253,7 +234,7 @@ class KeyValueExpr {
 	public var colon:Pos;
 	public var value:Expr;
 
-	public function new() {}
+public function new(?key:Expr, ?colon:Pos, ?value:Expr) {this.key = key;this.colon = colon;this.value = value;}
 }
 
 @:structInit
@@ -264,7 +245,7 @@ class ArrayType {
 	public var elt:Expr;
 	public var type:ExprType;
 
-	public function new() {}
+public function new(?lbrack:Pos, ?len:Expr, ?elt:Expr, ?type:ExprType) {this.lbrack = lbrack;this.len = len;this.elt = elt;this.type = type;}
 }
 
 @:structInit
@@ -275,14 +256,14 @@ class StructType {
 	public var incomplete:Bool;
 	public var type:ExprType;
 
-	public function new() {}
+public function new(?struct:Pos, ?fields:FieldList, ?incomplete:Bool, ?type:ExprType) {this.struct = struct;this.fields = fields;this.incomplete = incomplete;this.type = type;}
 }
 
 @:structInit
 class PointerType {
 	public var elem:ExprType;
 
-	public function new() {}
+public function new(?elem:ExprType) {this.elem = elem;}
 }
 
 @:structInit
@@ -294,7 +275,7 @@ class FuncType {
 	public var typeParams:FieldList;
 	public var type:ExprType;
 
-	public function new() {}
+public function new(?func:Pos, ?params:FieldList, ?results:FieldList, ?typeParams:FieldList, ?type:ExprType) {this.func = func;this.params = params;this.results = results;this.typeParams = typeParams;this.type = type;}
 }
 
 @:structInit
@@ -306,7 +287,7 @@ class InterfaceType {
 	public var incomplete:Bool;
 	public var type:ExprType;
 
-	public function new() {}
+public function new(?interfacePos:Pos, ?methods:FieldList, ?incomplete:Bool, ?type:ExprType) {this.interfacePos = interfacePos;this.methods = methods;this.incomplete = incomplete;this.type = type;}
 }
 
 @:structInit
@@ -317,7 +298,7 @@ class MapType {
 	public var value:Expr;
 	public var type:ExprType;
 
-	public function new() {}
+public function new(?map:Pos, ?key:Expr, ?value:Expr, ?type:ExprType) {this.map = map;this.key = key;this.value = value;this.type = type;}
 }
 
 @:structInit
@@ -329,7 +310,7 @@ class ChanType {
 	public var value:Expr;
 	public var type:ExprType;
 
-	public function new() {}
+public function new(?begin:Pos, ?arrow:Pos, ?dir:ChanDir, ?value:Expr, ?type:ExprType) {this.begin = begin;this.arrow = arrow;this.dir = dir;this.value = value;this.type = type;}
 }
 
 @:structInit
@@ -338,7 +319,7 @@ class BadStmt {
 	public var from:Pos;
 	public var to:Pos;
 
-	public function new() {}
+public function new(?from:Pos, ?to:Pos) {this.from = from;this.to = to;}
 }
 
 @:structInit
@@ -346,7 +327,7 @@ class DeclStmt {
 	// > Node,
 	public var decl:Decl;
 
-	public function new() {}
+public function new(?decl:Decl) {this.decl = decl;}
 }
 
 @:structInit
@@ -355,7 +336,7 @@ class EmptyStmt {
 	public var semicolon:Pos;
 	public var implicit:Bool;
 
-	public function new() {}
+public function new(?semicolon:Pos, ?implicit:Bool) {this.semicolon = semicolon;this.implicit = implicit;}
 }
 
 @:structInit
@@ -365,7 +346,7 @@ class LabeledStmt {
 	public var colon:Pos;
 	public var stmt:Stmt;
 
-	public function new() {}
+public function new(?label:Ident, ?colon:Pos, ?stmt:Stmt) {this.label = label;this.colon = colon;this.stmt = stmt;}
 }
 
 @:structInit
@@ -375,7 +356,7 @@ class ExprStmt {
 	public var end:Int;
 	public var pos:Int;
 
-	public function new() {}
+public function new(?x:Expr, ?end:Int, ?pos:Int) {this.x = x;this.end = end;this.pos = pos;}
 }
 
 @:structInit
@@ -385,7 +366,7 @@ class SendStmt {
 	public var arrow:Pos;
 	public var value:Expr;
 
-	public function new() {}
+public function new(?chan:Expr, ?arrow:Pos, ?value:Expr) {this.chan = chan;this.arrow = arrow;this.value = value;}
 }
 
 @:structInit
@@ -395,7 +376,7 @@ class IncDecStmt {
 	public var tokPos:Pos;
 	public var tok:Token;
 
-	public function new() {}
+public function new(?x:Expr, ?tokPos:Pos, ?tok:Token) {this.x = x;this.tokPos = tokPos;this.tok = tok;}
 }
 
 @:structInit
@@ -406,7 +387,7 @@ class AssignStmt {
 	public var tok:Token;
 	public var rhs:Array<Expr>;
 
-	public function new() {}
+public function new(?lhs:Array<Expr>, ?tokPos:Pos, ?tok:Token, ?rhs:Array<Expr>) {this.lhs = lhs;this.tokPos = tokPos;this.tok = tok;this.rhs = rhs;}
 }
 
 @:structInit
@@ -415,7 +396,7 @@ class GoStmt {
 	public var go:Pos;
 	public var call:CallExpr;
 
-	public function new() {}
+public function new(?go:Pos, ?call:CallExpr) {this.go = go;this.call = call;}
 }
 
 @:structInit
@@ -424,7 +405,7 @@ class DeferStmt {
 	public var defer:Pos;
 	public var call:CallExpr;
 
-	public function new() {}
+public function new(?defer:Pos, ?call:CallExpr) {this.defer = defer;this.call = call;}
 }
 
 @:structInit
@@ -434,7 +415,7 @@ class ReturnStmt {
 	// return TODO: return -> returnPos
 	public var results:Array<Expr>;
 
-	public function new() {}
+public function new(?returnPos:Pos, ?results:Array<Expr>) {this.returnPos = returnPos;this.results = results;}
 }
 
 @:structInit
@@ -443,7 +424,7 @@ class BranchStmt {
 	public var tok:Token;
 	public var label:Ident;
 
-	public function new() {}
+public function new(?tokPos:Pos, ?tok:Token, ?label:Ident) {this.tokPos = tokPos;this.tok = tok;this.label = label;}
 }
 
 @:structInit
@@ -452,7 +433,7 @@ class BlockStmt {
 	public var list:Array<Stmt>;
 	public var rbrace:Pos;
 
-	public function new() {}
+public function new(?lbrace:Pos, ?list:Array<Stmt>, ?rbrace:Pos) {this.lbrace = lbrace;this.list = list;this.rbrace = rbrace;}
 }
 
 @:structInit
@@ -474,7 +455,7 @@ class CaseClause {
 	public var colon:Pos;
 	public var body:Array<Stmt>;
 
-	public function new() {}
+public function new(?casePos:Pos, ?list:Array<Expr>, ?colon:Pos, ?body:Array<Stmt>) {this.casePos = casePos;this.list = list;this.colon = colon;this.body = body;}
 }
 
 @:structInit
@@ -485,7 +466,7 @@ class SwitchStmt {
 	public var tag:Expr;
 	public var body:BlockStmt;
 
-	public function new() {}
+public function new(?switchPos:Pos, ?init:Stmt, ?tag:Expr, ?body:BlockStmt) {this.switchPos = switchPos;this.init = init;this.tag = tag;this.body = body;}
 }
 
 @:structInit
@@ -496,7 +477,7 @@ class TypeSwitchStmt {
 	public var assign:Stmt;
 	public var body:BlockStmt;
 
-	public function new() {}
+public function new(?switchPos:Pos, ?init:Stmt, ?assign:Stmt, ?body:BlockStmt) {this.switchPos = switchPos;this.init = init;this.assign = assign;this.body = body;}
 }
 
 @:structInit
@@ -507,7 +488,7 @@ class CommClause {
 	public var colon:Pos;
 	public var body:Array<Stmt>;
 
-	public function new() {}
+public function new(?casePos:Pos, ?comm:Stmt, ?colon:Pos, ?body:Array<Stmt>) {this.casePos = casePos;this.comm = comm;this.colon = colon;this.body = body;}
 }
 
 @:structInit
@@ -515,7 +496,7 @@ class SelectStmt {
 	public var select:Pos;
 	public var body:BlockStmt;
 
-	public function new() {}
+public function new(?select:Pos, ?body:BlockStmt) {this.select = select;this.body = body;}
 }
 
 @:structInit
@@ -527,7 +508,7 @@ class ForStmt {
 	public var post:Stmt;
 	public var body:BlockStmt;
 
-	public function new() {}
+public function new(?forPos:Pos, ?init:Stmt, ?cond:Expr, ?post:Stmt, ?body:BlockStmt) {this.forPos = forPos;this.init = init;this.cond = cond;this.post = post;this.body = body;}
 }
 
 @:structInit
@@ -541,7 +522,7 @@ class RangeStmt {
 	public var x:Expr;
 	public var body:BlockStmt;
 
-	public function new() {}
+public function new(?forPos:Pos, ?key:Expr, ?value:Expr, ?tokPos:Pos, ?tok:Token, ?x:Expr, ?body:BlockStmt) {this.forPos = forPos;this.key = key;this.value = value;this.tokPos = tokPos;this.tok = tok;this.x = x;this.body = body;}
 }
 
 typedef Spec = Dynamic; // A go interface
@@ -555,26 +536,28 @@ class ImportSpec {
 	public var comment:CommentGroup;
 	public var endPos:Pos;
 
-	public function new() {}
+public function new(?doc:CommentGroup, ?name:String, ?path:String, ?comment:CommentGroup, ?endPos:Pos) {this.doc = doc;this.name = name;this.path = path;this.comment = comment;this.endPos = endPos;}
 }
 
 @:structInit
 class ValueSpec {
 	public var doc:CommentGroup;
-	names:Array<Ast.Ident>
-, public var type:Expr;
-public var values:Array<Expr>;
-public var comment:CommentGroup;
-public var pos:Int;
-public var end:Int;
+	public var names:Array<Ast.Ident>;
+	public var type:Expr;
+	public var values:Array<Expr>;
+	public var comment:CommentGroup;
+	public var pos:Int;
+	public var end:Int;
 
-	public function new() {}
-} @:structInit
+public function new(?doc:CommentGroup, ?names:Array<Ast.Ident>, ?type:Expr, ?values:Array<Expr>, ?comment:CommentGroup, ?pos:Int, ?end:Int) {this.doc = doc;this.names = names;this.type = type;this.values = values;this.comment = comment;this.pos = pos;this.end = end;}
+} 
+
+@:structInit
 class ImplicitType {
 	public var name:String;
 	public var path:String;
 
-	public function new() {}
+public function new(?name:String, ?path:String) {this.name = name;this.path = path;}
 }
 
 @:structInit
@@ -585,22 +568,19 @@ class TypeSpec {
 	public var type:Expr;
 	public var comment:CommentGroup;
 	public var params:FieldList;
-	methods:Array<{
-		name:String,
-		type:ExprType,
-		recv:ExprType,
-		index:Array<Int>
-	}>
-, public var pos:Int;
-public var end:Int;
+	public var methods:Array<{name:String,type:ExprType,recv:ExprType,index:Array<Int>}>;
+	public var pos:Int;
+	public var end:Int;
 
-	public function new() {}
-} @:structInit
+public function new(?doc:CommentGroup, ?name:Ident, ?assign:Pos, ?type:Expr, ?comment:CommentGroup, ?params:FieldList, ?methods:Array<{name:String,type:ExprType,recv:ExprType,index:Array<Int>}>, ?pos:Int, ?end:Int) {this.doc = doc;this.name = name;this.assign = assign;this.type = type;this.comment = comment;this.params = params;this.methods = methods;this.pos = pos;this.end = end;}
+}
+
+@:structInit
 class BadDecl {
 	public var from:Pos;
 	public var to:Pos;
 
-	public function new() {}
+public function new(?from:Pos, ?to:Pos) {this.from = from;this.to = to;}
 }
 
 @:structInit
@@ -612,7 +592,7 @@ class GenDecl {
 	public var specs:Array<Spec>;
 	public var rparen:Pos;
 
-	public function new() {}
+public function new(?doc:CommentGroup, ?tokPos:Pos, ?tok:Token, ?lparen:Pos, ?specs:Array<Spec>, ?rparen:Pos) {this.doc = doc;this.tokPos = tokPos;this.tok = tok;this.lparen = lparen;this.specs = specs;this.rparen = rparen;}
 }
 
 @:structInit
@@ -626,7 +606,7 @@ class FuncDecl {
 	public var pos:Int;
 	public var end:Int;
 
-	public function new() {}
+public function new(?doc:CommentGroup, ?recv:FieldList, ?typeParams:FieldList, ?name:Ident, ?type:FuncType, ?body:BlockStmt, ?pos:Int, ?end:Int) {this.doc = doc;this.recv = recv;this.typeParams = typeParams;this.name = name;this.type = type;this.body = body;this.pos = pos;this.end = end;}
 }
 
 @:structInit
@@ -637,7 +617,7 @@ class Object {
 	public var data:Any;
 	public var type:Any;
 
-	public function new() {}
+public function new(?kind:ObjKind, ?name:String, ?decl:Any, ?data:Any, ?type:Any) {this.kind = kind;this.name = name;this.decl = decl;this.data = data;this.type = type;}
 }
 
 @:structInit
@@ -645,6 +625,7 @@ class Position {}
 
 @:structInit
 typedef Pos = Int;
+
 
 enum abstract Token(String) {
 	public final ILLEGAL = "ILLEGAL";

--- a/src/Typer.hx
+++ b/src/Typer.hx
@@ -1,7 +1,5 @@
-import Ast.GenDecl;
 import haxe.ds.Either;
 import haxe.ds.Option;
-import Ast.FuncDecl;
 import haxe.DynamicAccess;
 import haxe.io.Path;
 import haxe.macro.Expr;
@@ -139,9 +137,9 @@ function main(data:DataType, instance:Main.InstanceData) {
 			for (decl in file.decls) {
 				switch decl.id {
 					case "GenDecl":
-						declGens.push(new GenDecl(decl.doc, decl.tokPos, decl.tok, decl.lparen, decl.specs, decl.rparen));
+						declGens.push(new Ast.GenDecl(decl.doc, decl.tokPos, decl.tok, decl.lparen, decl.specs, decl.rparen));
 					case "FuncDecl":
-						declFuncs.push(new FuncDecl(decl.doc, decl.recv, decl.typeParams, decl.name, decl.type, decl.body, decl.pos, decl.end));
+						declFuncs.push(new Ast.FuncDecl(decl.doc, decl.recv, decl.typeParams, decl.name, decl.type, decl.body, decl.pos, decl.end));
 					default:
 				}
 			}
@@ -169,15 +167,15 @@ function main(data:DataType, instance:Main.InstanceData) {
 			info.locals.clear();
 			info.localUnderlyingNames.clear();
 			info.data = data;
-			final pkgDoc = getDoc({doc: file.doc});
+			final pkgDoc = getDoc(cast file);
 			var declFuncs:Array<Ast.FuncDecl> = [];
 			var declGens:Array<Ast.GenDecl> = [];
 			for (decl in file.decls) {
 				switch decl.id {
 					case "GenDecl":
-						declGens.push(new GenDecl(decl.doc, decl.tokPos, decl.tok, decl.lparen, decl.specs, decl.rparen));
+						declGens.push(new Ast.GenDecl(decl.doc, decl.tokPos, decl.tok, decl.lparen, decl.specs, decl.rparen));
 					case "FuncDecl":
-						var decl:Ast.FuncDecl = new FuncDecl(decl.doc, decl.recv, decl.typeParams, decl.name, decl.type, decl.body, decl.pos, decl.end);
+						var decl:Ast.FuncDecl = new Ast.FuncDecl(decl.doc, decl.recv, decl.typeParams, decl.name, decl.type, decl.body, decl.pos, decl.end);
 						if (decl.name.name != "_")
 							declFuncs.push(decl);
 					default:
@@ -5626,7 +5624,7 @@ private function typeFieldListMethods(list:Ast.FieldList, info:Info):Array<Field
 		var params = typeFieldListArgs(expr.params, info);
 		if (ret == null || params == null)
 			continue;
-		final doc = getDoc(field) + getComment(field);
+		final doc = getDoc(cast field) + getComment(field);
 		for (n in field.names) {
 			var name = n.name;
 			fields.push({
@@ -5659,7 +5657,7 @@ private function typeFields(list:Array<FieldType>, info:Info, access:Array<Acces
 		}
 		if (field.tag != "")
 			meta.push({name: ":tag", pos: null, params: [makeString(field.tag)]});
-		var doc:String = getDoc({doc: docs == null ? null : docs[i]}) + getComment({comment: comments == null ? null : comments[i]});
+		var doc:String = getDoc(cast {doc: docs == null ? null : docs[i]}) + getComment({comment: comments == null ? null : comments[i]});
 		fields.push({
 			name: nameIdent(name, false, false, info),
 			pos: null,
@@ -6352,7 +6350,7 @@ private function getComment(value:{comment:Ast.CommentGroup}):String {
 	return source;
 }
 
-private function getDoc(value:{doc:Ast.CommentGroup}):String {
+private function getDoc(value:Ast.HasDoc):String {
 	if (value.doc == null || value.doc.list == null)
 		return "";
 	var source = value.doc.list.join("\n");

--- a/src/Typer.hx
+++ b/src/Typer.hx
@@ -167,7 +167,7 @@ function main(data:DataType, instance:Main.InstanceData) {
 			info.locals.clear();
 			info.localUnderlyingNames.clear();
 			info.data = data;
-			final pkgDoc = getDoc(cast file);
+			final pkgDoc = getDoc(file);
 			var declFuncs:Array<Ast.FuncDecl> = [];
 			var declGens:Array<Ast.GenDecl> = [];
 			for (decl in file.decls) {
@@ -6608,12 +6608,7 @@ typedef PackageType = {
 	path:String,
 	name:String,
 	order:Array<String>,
-	files:Array<{
-		path:String,
-		location:String,
-		decls:Array<Ast.FuncOrGenDecl>,
-		doc:Ast.CommentGroup,
-	}>
+	files:Array<FileStruct>
 }; // filepath of export.json also stored here
 
 typedef Module = {
@@ -6636,3 +6631,17 @@ typedef FileType = {
 	location:String,
 	isMain:Bool
 }; // location is the global path to the file
+
+class FileStruct implements Ast.HasDoc {
+	public var path:String;
+	public var location:String;
+	public var decls:Array<Ast.FuncOrGenDecl>;
+	public var doc:Ast.CommentGroup;
+
+	public function new(?path:String, ?location:String, ?decls:Array<Ast.FuncOrGenDecl>, doc:Ast.CommentGroup) {
+		this.path = path;
+		this.location = location;
+		this.decls = decls;
+		this.doc = doc;
+	}
+}

--- a/src/Typer.hx
+++ b/src/Typer.hx
@@ -141,7 +141,7 @@ function main(data:DataType, instance:Main.InstanceData) {
 					case "GenDecl":
 						declGens.push(new GenDecl(decl.doc, decl.tokPos, decl.tok, decl.lparen, decl.specs, decl.rparen));
 					case "FuncDecl":
-						declFuncs.push(new FuncDecl(decl.doc, decl.recv, decl.typeParams, decl.name. decl.type, decl.body, decl.ps, decl.end));
+						declFuncs.push(new FuncDecl(decl.doc, decl.recv, decl.typeParams, decl.name, decl.type, decl.body, decl.pos, decl.end));
 					default:
 				}
 			}
@@ -177,7 +177,7 @@ function main(data:DataType, instance:Main.InstanceData) {
 					case "GenDecl":
 						declGens.push(new GenDecl(decl.doc, decl.tokPos, decl.tok, decl.lparen, decl.specs, decl.rparen));
 					case "FuncDecl":
-						var decl:Ast.FuncDecl = new FuncDecl(decl.doc, decl.recv, decl.typeParams, decl.name. decl.type, decl.body, decl.ps, decl.end);
+						var decl:Ast.FuncDecl = new FuncDecl(decl.doc, decl.recv, decl.typeParams, decl.name, decl.type, decl.body, decl.pos, decl.end);
 						if (decl.name.name != "_")
 							declFuncs.push(decl);
 					default:

--- a/src/Typer.hx
+++ b/src/Typer.hx
@@ -1,3 +1,7 @@
+import Ast.GenDecl;
+import haxe.ds.Either;
+import haxe.ds.Option;
+import Ast.FuncDecl;
 import haxe.DynamicAccess;
 import haxe.io.Path;
 import haxe.macro.Expr;
@@ -135,10 +139,9 @@ function main(data:DataType, instance:Main.InstanceData) {
 			for (decl in file.decls) {
 				switch decl.id {
 					case "GenDecl":
-						declGens.push(decl);
+						declGens.push(new GenDecl(decl.doc, decl.tokPos, decl.tok, decl.lparen, decl.specs, decl.rparen));
 					case "FuncDecl":
-						var decl:Ast.FuncDecl = decl;
-						declFuncs.push(decl);
+						declFuncs.push(new FuncDecl(decl.doc, decl.recv, decl.typeParams, decl.name. decl.type, decl.body, decl.ps, decl.end));
 					default:
 				}
 			}
@@ -172,9 +175,9 @@ function main(data:DataType, instance:Main.InstanceData) {
 			for (decl in file.decls) {
 				switch decl.id {
 					case "GenDecl":
-						declGens.push(decl);
+						declGens.push(new GenDecl(decl.doc, decl.tokPos, decl.tok, decl.lparen, decl.specs, decl.rparen));
 					case "FuncDecl":
-						var decl:Ast.FuncDecl = decl;
+						var decl:Ast.FuncDecl = new FuncDecl(decl.doc, decl.recv, decl.typeParams, decl.name. decl.type, decl.body, decl.ps, decl.end);
 						if (decl.name.name != "_")
 							declFuncs.push(decl);
 					default:
@@ -6609,7 +6612,7 @@ typedef PackageType = {
 	files:Array<{
 		path:String,
 		location:String,
-		decls:Array<Dynamic>,
+		decls:Array<Ast.FuncOrGenDecl>,
 		doc:Ast.CommentGroup,
 	}>
 }; // filepath of export.json also stored here

--- a/src/Typer.hx
+++ b/src/Typer.hx
@@ -169,7 +169,7 @@ function main(data:DataType, instance:Main.InstanceData) {
 			info.locals.clear();
 			info.localUnderlyingNames.clear();
 			info.data = data;
-			final pkgDoc = getDoc(file);
+			final pkgDoc = getDoc({doc: file.doc});
 			var declFuncs:Array<Ast.FuncDecl> = [];
 			var declGens:Array<Ast.GenDecl> = [];
 			for (decl in file.decls) {

--- a/src/Typer.hx
+++ b/src/Typer.hx
@@ -5657,7 +5657,8 @@ private function typeFields(list:Array<FieldType>, info:Info, access:Array<Acces
 		}
 		if (field.tag != "")
 			meta.push({name: ":tag", pos: null, params: [makeString(field.tag)]});
-		var doc:String = getDoc(cast {doc: docs == null ? null : docs[i]}) + getComment({comment: comments == null ? null : comments[i]});
+		//casting here should work
+		var doc:String = getDoc(cast {doc: docs == null ? null : docs[i]}) + getComment({comment: comments == null ? null : comments[i]}); 
 		fields.push({
 			name: nameIdent(name, false, false, info),
 			pos: null,

--- a/src/Typer.hx
+++ b/src/Typer.hx
@@ -6617,8 +6617,18 @@ typedef PackageType = {
 	}>
 }; // filepath of export.json also stored here
 
-typedef Module = {name:String, path:String, files:Array<FileType>, isMain:Bool}
-typedef ImportType = {path:Array<String>, alias:String, doc:String}
+typedef Module = {
+	name:String, 
+	path:String, 
+	files:Array<FileType>, 
+	isMain:Bool
+}
+
+typedef ImportType = {
+	path:Array<String>, 
+	alias:String, 
+	doc:String
+}
 
 typedef FileType = {
 	name:String,


### PR DESCRIPTION
This can boost performance on static targets, since typedefs are compiled down to dynamic objects, which are known to be slow.