### PR TITLE
Basic benchmark support in testing

### DIFF
--- a/src/Main.hx
+++ b/src/Main.hx
@@ -80,6 +80,7 @@ function compileArgs(args:Array<String>):InstanceData {
 		["-norun", "--norun"] => () -> instance.noRun = true, @doc("go test")
 		["-nocomments", "--nocomments"] => () -> instance.noComments = true, @doc("no comments")
 		["-test", "--test"] => () -> instance.test = true,
+		["-bench", "--bench"] => () -> instance.bench = true,
 		["-vartrace", "--vartrace", "-varTrace", "--varTrace"] => () -> instance.varTraceBool = true,
 		["-stack", "--stack"] => () -> instance.stackBool = true,
 		@doc("disable the usage of the build cache")
@@ -532,6 +533,10 @@ private function runBuildTools(modules:Array<Typer.Module>, instance:InstanceDat
 		commands.push("-D");
 		commands.push(define);
 	}
+	if (instance.bench) {
+		commands.push("-D");
+		commands.push("bench");
+	}
 	if (instance.target != "" && instance.target != "interp") {
 		final main = paths.length > 0 ? paths[0] : "";
 		for (command in buildTarget(instance.target, instance.targetOutput).split(" "))
@@ -770,6 +775,7 @@ class InstanceData {
 	public var useCache: Bool = true;
 	public var cleanCache: Bool = false;
 	public var test:Bool = false;
+	public var bench:Bool = false;
 
 	public var noCommentsBool:Bool = false;
 

--- a/src/Patch.hx
+++ b/src/Patch.hx
@@ -1810,8 +1810,15 @@ final list = [
 		final args = @:define("(sys || hxnodejs)", []) Sys.args();
 		var testlist:Array<stdgo._internal.testing.Testing_internaltest.InternalTest> = [];
 		var runArgBool = false;
+		var benchBool = false;
+		if (haxe.macro.Compiler.getDefine("bench") != null)
+			benchBool = true;
 		var excludes:Array<String> = [];
 		for (i in 0...args.length) {
+			if (args[i] == "-bench" || args[i] == "--bench") {
+				benchBool = true;
+				continue;
+			}
 			if ((args[i] == "-run" || args[i] == "--run") && i < args.length - 1) {
 				final match = args[i + 1];
 				runArgBool = true;
@@ -1820,7 +1827,7 @@ final list = [
 						testlist.push(test);
 					}
 				}
-				break;
+				continue;
 			}
 		}
 		if (!runArgBool)
@@ -1835,6 +1842,7 @@ final list = [
 			}
 		}
 		var m = new stdgo._internal.testing.Testing_m.M(_deps, testlist, _benchmarks, _fuzzTargets, _examples);
+		@:privateAccess m.benchBool = benchBool;
 		return m;
 	},
 	"testing:testing" => macro return true,
@@ -1845,6 +1853,35 @@ final list = [
 		return 0;
 	},
 	"testing:verbose" => macro return false,
+	"testing.B:resetTimer" => macro {
+		if (_b._timerOn) {
+			/*runtime.ReadMemStats(&memStats)
+			b.startAllocs = memStats.Mallocs
+			b.startBytes = memStats.TotalAlloc*/
+			_b._common._start = stdgo._internal.time.Time_now.now();
+		}
+		_b._common._duration = 0;
+		_b._netAllocs = 0;
+		_b._netBytes = 0;
+	},
+	"testing.B:startTimer" => macro {
+		if (!_b._timerOn) {
+			_b._common._start = stdgo._internal.time.Time_now.now();
+			_b._timerOn = true;
+		}
+	},
+	"testing.B:stopTimer" => macro {
+		if (_b._timerOn) {
+			_b._common._duration += stdgo._internal.time.Time_since.since(_b._common._start);
+			_b._timerOn = false;
+		}
+	},
+	"testing.B:run" => macro {
+		stdgo.Go.println("- SUBRUN  " + _name.toString());
+		_b.n = 1;
+		_f(_b);
+		return true;
+	},
 	"testing.T_:run" => macro {
 		stdgo.Go.println("- SUBRUN  " + _name.toString());
 		_f(_t);
@@ -1967,6 +2004,39 @@ final list = [
 			}
 			stdgo.Go.println(output.toString());
 		}
+		if (@:privateAccess _m.benchBool) {
+			stdgo.Go.println("BENCHMARKING");
+			for (bench in _m._benchmarks) {
+				var b = new stdgo._internal.testing.Testing_b.B();
+				var error = false;
+				try {
+					b.resetTimer();
+					b.startTimer();
+					bench.f(b);
+					b.stopTimer();
+				} catch (e) {
+					stdgo.Go.println(e.details());
+					error = true;
+				}
+				for (f in b._common._cleanups) {
+					f();
+				}
+				if (error) {
+					final reason = '\n-- FAIL: ${bench.name.toString()}';
+					stdgo.Go.println(reason);
+					exitCodeReason = reason;
+					_m._exitCode = 1;
+				} else if (chatty) {
+					if (b.skipped()) {
+						stdgo.Go.println('\n-- SKIP: ${bench.name.toString()}');
+					} else {
+						final output = b._common._duration.string().toString();
+						// get allocs and memory here
+						stdgo.Go.println('\n-- BENCH: ${bench.name.toString()}' + ' ' + output);
+					}
+				}
+			}
+		}
 		trace("exitCode: " + _m._exitCode);
 		trace("exitCodeReason: " + exitCodeReason);
 		return _m._exitCode;
@@ -2074,6 +2144,10 @@ final replace = [
 ];
 
 final structs = [
+	"testing:M" => macro {
+		@:local
+		var benchBool = false;
+	},
 	"testing:T_" => macro {
 		@:local
 		var output:StringBuf = null;


### PR DESCRIPTION
This adds the benchmark system into ``testing`` stdlib. Very basic but sets the foundation to be able to get benchmark results with test suites that have benchmarks. At the moment it should mainly be used on the stdlibs such as ``unicode/utf8``

It is implemented by patching in the functionality with ````src/Patch.hx`` in the future it will be possible to have go2hx compile the testing pkg, but for now it is unable to.

Calling example:
```haxe
haxelib run go2hx -rebuild -test -bench unicode/utf8
```

Protip:
``-rebuild`` is a very useful flag because it will recompile the compiler every run, in case you are making changes to the compiler.

If you want changes to take effect when modifying testing inside of ``src/Patch.hx`` run the command:
```haxe
haxe --run Make std testing
```


## Known problems
1. timer is bugged and only returns back whole numbers and therefore is extremely imprecise and not very usable.
2. Most of the benchmarks are done via the ``b.N`` pattern, where the benchmark system reruns the benchmarks increasing the number of iterations ``N`` until the results are stable. Currently this is not handled at all, and Go benchmark metrics assume a per iteration for all of the benchmark stats.
3. https://pkg.go.dev/testing#B.Loop is the new system to do iterations with benchmarks, but there is no implementation, and was added recently in Go version 1.24.0, so all of the stdlib won't use it because the compiler is locked to version ``1.21.3`` at the moment.
4. Benchmarks are much more useful if number of allocations, and memory stats are also included in the benchmark output.

## Resources
- [docs on b.N style benchmarks](https://pkg.go.dev/testing#hdr-b_N_style_benchmarks)
- [hl get number of allocs](https://api.haxe.org/hl/Gc.html#stats)
- [benchmark format](https://go.googlesource.com/proposal/+/master/design/14313-benchmark-format.md)